### PR TITLE
Fixes for manifest-path

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -67,6 +67,7 @@ pub(crate) fn run(
     triple: &str,
     platform: u8,
     cargo_args: &Vec<String>,
+    cargo_manifest: &Path,
 ) -> std::process::ExitStatus {
     let target_ar = Path::new(&ndk_home).join(toolchain_suffix(&triple, &ARCH, "ar"));
     let target_linker = Path::new(&ndk_home).join(clang_suffix(&triple, &ARCH, platform, ""));
@@ -81,14 +82,29 @@ pub(crate) fn run(
     log::debug!("linker: {}", &target_linker.display());
     log::debug!("cargo: {}", &cargo_bin);
 
-    Command::new(cargo_bin)
+    let mut cargo_cmd = Command::new(cargo_bin);
+    cargo_cmd
         .current_dir(dir)
         .env(ar_key, &target_ar)
         .env(cc_key, &target_linker)
         .env(cxx_key, &target_cxx)
         .env(cargo_env_target_cfg(&triple, "ar"), &target_ar)
         .env(cargo_env_target_cfg(&triple, "linker"), &target_linker)
-        .args(cargo_args)
+        .args(cargo_args);
+
+    match dir.parent() {
+        Some(parent) => {
+            if parent != dir {
+                log::debug!("Working directory does not match manifest-path");
+                cargo_cmd.arg("--manifest-path").arg(&cargo_manifest);
+            }
+        }
+        _ => {
+            log::warn!("Parent of current working diredtory does not exist");
+        }
+    }
+
+    cargo_cmd
         .arg("--target")
         .arg(&triple)
         .status()

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -100,7 +100,7 @@ pub(crate) fn run(
             }
         }
         _ => {
-            log::warn!("Parent of current working diredtory does not exist");
+            log::warn!("Parent of current working directory does not exist");
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,13 +106,17 @@ pub(crate) fn run(args: Vec<String>) {
         }
     };
 
+    let working_dir = std::env::current_dir().expect("current directory could not be resolved");
+    let working_dir_cargo = working_dir.join("Cargo.toml");
+    let cargo_manifest = args.manifest_path.as_ref().unwrap_or(&working_dir_cargo);
+
     if args.cargo_args.is_empty() {
         log::error!("No args found to pass to cargo!");
         log::error!("You still need to specify build arguments to cargo to achieve anything. :)");
         std::process::exit(1);
     }
-
-    let metadata = match MetadataCommand::new().manifest_path("./Cargo.toml").exec() {
+    
+    let metadata = match MetadataCommand::new().manifest_path(cargo_manifest).exec() {
         Ok(v) => v,
         Err(e) => {
             log::error!("Failed to load Cargo.toml in current directory.");
@@ -136,9 +140,7 @@ pub(crate) fn run(args: Vec<String>) {
             return;
         }
     };
-    let working_dir = std::env::current_dir().expect("current directory could not be resolved");
-    let working_dir_cargo = working_dir.join("Cargo.toml");
-    let cargo_manifest = args.manifest_path.as_ref().unwrap_or(&working_dir_cargo);
+  
     let config = match crate::meta::config(&cargo_manifest, is_release) {
         Ok(v) => v,
         Err(e) => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,10 +21,6 @@ struct Args {
         help = "triple for the target(s)\n                           Supported: armeabi-v7a arm64-v8a x86 x86_64."
     )]
     target: Vec<Target>,
-    #[options(
-        help = "If $(PWD) is not a Rust project, specify the location of the Cargo.toml (note the restrictions https://github.com/rust-lang/cargo/issues/7856)"
-    )]
-    manifest_path: Option<PathBuf>,
 
     #[options(
         meta = "DIR",
@@ -123,6 +119,10 @@ pub(crate) fn run(args: Vec<String>) {
     if args.cargo_args.is_empty() {
         log::error!("No args found to pass to cargo!");
         log::error!("You still need to specify build arguments to cargo to achieve anything. :)");
+        std::process::exit(1);
+    }
+    if args.cargo_args.contains(&"--manifest-path".to_string()) {
+        log::error!("Manifest path should be supplied as an argument to cargo ndk (e.g. before build)");
         std::process::exit(1);
     }
     


### PR DESCRIPTION
Hi 

Sorry my last Pull Request did not fix all occurences. I did not thoroughly check the different cases which is why I missed it...

This time I ran tests on different systems and with different configurations.

I also added the error message, for when the --manifest-path is supplied as a cargo_arg. Maybe it would be better to rename it to avoid confusion with the original cargo arg? 

Sorry again for the inconvenience... 