### PR TITLE
Expose API level to user

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -178,6 +178,7 @@ pub(crate) fn run(args: Vec<String>) {
     }
 
     log::info!("NDK API level: {}", platform);
+    std::env::set_var("CARGO_NDK_ANDROID_PLATFORM", platform.to_string());
     log::info!(
         "Building targets: {}",
         targets


### PR DESCRIPTION
This is the only variable that is left.
NDK uses 16 by default so it would be better to expose this variable too