### PR TITLE
Try find the highest NDK version from NDK env var

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,11 @@ edition = "2018"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
+cargo_metadata = "0.14.0"
+env_logger = "0.9.0"
 gumdrop = "0.8.0"
-toml = "0.5.6"
-serde = { version = "1.0.114", features = ["derive"] }
-pathos = "0.3.0-pre.2"
-env_logger = "0.7.1"
-log = "0.4.8"
-cargo_metadata = "0.10.0"
+log = "0.4.14"
+pathos = "0.3.0-pre.4"
+semver = "1.0.3"
+serde = { version = "1.0.126", features = ["derive"] }
+toml = "0.5.8"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -66,7 +66,7 @@ pub(crate) fn run(
     ndk_home: &Path,
     triple: &str,
     platform: u8,
-    cargo_args: &Vec<String>,
+    cargo_args: &[String],
     cargo_manifest: &Path,
 ) -> std::process::ExitStatus {
     let target_ar = Path::new(&ndk_home).join(toolchain_suffix(&triple, &ARCH, "ar"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod cli;
 mod meta;
 
 fn main() {
-    env_logger::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     if env::var("CARGO").is_err() {
         eprintln!("This binary may only be called via `cargo ndk`.");


### PR DESCRIPTION
Currently `cargo-ndk` only tries to find the latest NDK version when either `ANDROID_SDK_HOME` is defined or none of the typical env vars are present. For `ANDROID_NDK_HOME` and `NDK_HOME` however, no resultion is currently done.

This adds the missing resolution step but allows a fallback in case the env var doesn't point to the `.../ndk` folder but already a specific version like `.../ndk/X.Y.Z`.

I updated all deps to the latest version as well. That was mostly done to avoid dependency duplicates as semver was already pulled in as transitive dependency.