### PR TITLE
support ANDROID_NDK and ANDROID_NDK_ROOT env vars as used by cmake

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,6 +71,10 @@ fn highest_version_ndk_in_path(ndk_dir: &Path) -> Option<PathBuf> {
 }
 
 fn derive_ndk_path() -> Option<PathBuf> {
+    if let Some(path) = env::var_os("ANDROID_NDK").or_else(|| env::var_os("ANDROID_NDK_ROOT")) {
+        return Some(PathBuf::from(path));
+    }
+
     if let Some(path) = env::var_os("ANDROID_NDK_HOME").or_else(|| env::var_os("NDK_HOME")) {
         let path = PathBuf::from(path);
         return highest_version_ndk_in_path(&path).or(Some(path));


### PR DESCRIPTION
Treats these env vars in a stricter way than ANDROID_NDK_HOME and
NDK_HOME: does not allow them to be directories containing multiple NDK
versions (this matches the documented requirements on these env vars in
cmake,
https://cmake.org/cmake/help/latest/variable/CMAKE_ANDROID_NDK.html#variable:CMAKE_ANDROID_NDK)

Fixes #39