### PR TITLE
use `llvm-strip` and `llvm-ar` if the arch-specific-named strip and ar are not present

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -120,7 +120,10 @@ pub(crate) fn run(
 }
 
 pub(crate) fn strip(ndk_home: &Path, triple: &str, bin_path: &Path) -> std::process::ExitStatus {
-    let target_strip = Path::new(&ndk_home).join(toolchain_suffix(triple, ARCH, "strip"));
+    let mut target_strip = ndk_home.join(toolchain_suffix(triple, ARCH, "strip"));
+    if !target_strip.exists() {
+        target_strip = ndk_home.join("llvm-strip");
+    }
 
     log::debug!("strip: {}", &target_strip.display());
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -69,9 +69,13 @@ pub(crate) fn run(
     cargo_args: &[String],
     cargo_manifest: &Path,
 ) -> std::process::ExitStatus {
-    let target_ar = Path::new(&ndk_home).join(toolchain_suffix(triple, ARCH, "ar"));
-    let target_linker = Path::new(&ndk_home).join(clang_suffix(triple, ARCH, platform, ""));
-    let target_cxx = Path::new(&ndk_home).join(clang_suffix(triple, ARCH, platform, "++"));
+    let mut target_ar = ndk_home.join(toolchain_suffix(triple, ARCH, "ar"));
+    if !target_ar.exists() {
+        target_ar = ndk_home.join("llvm-ar");
+    }
+
+    let target_linker = ndk_home.join(clang_suffix(triple, ARCH, platform, ""));
+    let target_cxx = ndk_home.join(clang_suffix(triple, ARCH, platform, "++"));
 
     let cc_key = format!("CC_{}", &triple);
     let ar_key = format!("AR_{}", &triple);


### PR DESCRIPTION
Should fix #38