### PR TITLE
Add ability to pass sysroot setting when building w/ bindgen

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,6 +48,13 @@ struct Args {
         help = "path to Cargo.toml\n                           (limitations: https://github.com/rust-lang/cargo/issues/7856)"
     )]
     manifest_path: Option<PathBuf>,
+
+    #[options(
+        no_short,
+        help = "set bindgen-specific environment variables (BINDGEN_EXTRA_CLANG_ARGS_*) when building",
+        default = "false"
+    )]
+    bindgen: bool,
 }
 
 fn highest_version_ndk_in_path(ndk_dir: &Path) -> Option<PathBuf> {
@@ -222,6 +229,7 @@ pub(crate) fn run(args: Vec<String>) {
             platform,
             &args.cargo_args,
             cargo_manifest,
+            args.bindgen,
         );
         let code = status.code().unwrap_or(-1);
 


### PR DESCRIPTION
This is a minor modification on #53 to get it merged. The behaviour is now no longer always active, but can be enabled with the `--bindgen` flag. I was able to check, with our own build, that both absent and present `--bindgen` flag works as expected for us.
