### PR TITLE
Provide libgcc linker script workaround for NDK >= 23

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -272,6 +272,7 @@ pub(crate) fn run(args: Vec<String>) {
 
         let status = crate::cargo::run(
             &working_dir,
+            &metadata.target_directory,
             &ndk_home,
             ndk_version.clone(),
             triple,


### PR DESCRIPTION
libgcc was removed from NDK v23 which breaks Rust builds against pre-built standard libraries that were linked against libgcc instead of libunwind.

As a workaround this ensures that there is a libgcc.a in the library search paths which is a linker script that will redirect to link with libunwind instead.

The libgcc.a linker script is created under:
 `target/cargo-ndk/libgcc_workaround/libgcc.a`

Fixes: #22

_For reference the underlying issue has been fixed upstream but it still depends on building the std library from source (via [`-Zbuild-std`](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std)) instead of using the pre-built libraries distributed via rustup. This currently means using a nightly toolchain. See: https://github.com/rust-lang/rust/pull/85806_