### PR TITLE
Consider all widely-used NDK/SDK env vars

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,12 +75,18 @@ fn highest_version_ndk_in_path(ndk_dir: &Path) -> Option<PathBuf> {
 }
 
 fn derive_ndk_path() -> Option<PathBuf> {
-    if let Some(path) = env::var_os("ANDROID_NDK_HOME").or_else(|| env::var_os("NDK_HOME")) {
+    if let Some(path) = env::var_os("ANDROID_NDK_HOME")
+        .or_else(|| env::var_os("ANDROID_NDK_ROOT"))
+        .or_else(|| env::var_os("NDK_HOME"))
+    {
         let path = PathBuf::from(path);
         return highest_version_ndk_in_path(&path).or(Some(path));
     };
 
-    if let Some(sdk_path) = env::var_os("ANDROID_SDK_HOME") {
+    if let Some(sdk_path) = env::var_os("ANDROID_HOME")
+        .or_else(|| env::var_os("ANDROID_SDK_HOME"))
+        .or_else(|| env::var_os("ANDROID_SDK_ROOT"))
+    {
         let ndk_path = PathBuf::from(&sdk_path).join("ndk");
         if let Some(v) = highest_version_ndk_in_path(&ndk_path) {
             return Some(v);


### PR DESCRIPTION
There's not really any 'correct' variables to use for detecting an
Android NDK or SDK but there are some more common variables that
cargo-ndk can check to maximize the chance of finding an NDK based
on a user's existing environment.

This fixes a minor paper-cut issue that just reduces the need
to store the NDK/SDK paths in multiple environment variables to
appease different tools that check different variables.

They are approximately (subjectively) checked in order of officialness.