### PR TITLE
handle error if moving of .so file fails

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -377,13 +377,17 @@ pub(crate) fn run(args: Vec<String>) {
 
             log::trace!("Target path: {}", dir);
 
-            let so_files = std::fs::read_dir(&dir)
-                .ok()
-                .unwrap()
-                .flat_map(Result::ok)
-                .map(|x| x.path())
-                .filter(|x| x.extension() == Some(OsStr::new("so")))
-                .collect::<Vec<_>>();
+            let so_files = match std::fs::read_dir(&dir) {
+                Ok(dir) => dir
+                    .flat_map(Result::ok)
+                    .map(|x| x.path())
+                    .filter(|x| x.extension() == Some(OsStr::new("so")))
+                    .collect::<Vec<_>>(),
+                Err(e) => {
+                    log::error!("{} {:?}", e, dir);
+                    std::process::exit(1);
+                }
+            };
 
             if so_files.is_empty() {
                 log::error!("No .so files found in path {:?}", dir);


### PR DESCRIPTION
This PR removes the `.unwrap()` call on:
```rust
let so_files = std::fs::read_dir(&dir)
    .ok()
    .unwrap()
    .flat_map(Result::ok)
    .map(|x| x.path())
    .filter(|x| x.extension() == Some(OsStr::new("so")))
    .collect::<Vec<_>>();
```
And instead logs the error to the console.

I just spent an hour trying to build a library with `cargo ndk -t x86_64 -o app/src/main/jniLibs/  build -r` and it always failed until I noticed that cargo-ndk tries to copy from the debug and not the release folder.

I hope this will save time for someone else in the future :smiley: