### PR TITLE
Fix windows slash in sysroot path

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -254,7 +254,7 @@ pub(crate) fn run(
             &target_sysroot.display(),
             extra_include
         );
-        cargo_cmd.env(bindgen_clang_args_key, bindgen_args.clone());
+        cargo_cmd.env(bindgen_clang_args_key, bindgen_args.clone().replace('\\', "/"));
         log::debug!("bindgen_args={}", bindgen_args);
     }
 


### PR DESCRIPTION
This PR fixes sysroot paths #84 

My little research led me to the fact that for some reason `\\` disappears from the paths