### PR TITLE
Support patching r25 NDK with quoting workaround on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: cargo install --path .
       - name: Run test
         working-directory: example
-        run: cargo ndk build
+        run: cargo ndk --apply-ndk-quote-workaround build
       - name: Check code formatting
         continue-on-error: true
         run: cargo fmt --all -- --check

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,13 @@ struct Args {
     #[options(no_short, help = "disable stripping debug symbols", default = "false")]
     no_strip: bool,
 
+    #[options(
+        no_short,
+        help = "apply a quoting workaround to NDK .cmd wrappers on Windows (https://github.com/android/ndk/issues/1856)",
+        default = "false"
+    )]
+    apply_ndk_quote_workaround: bool,
+
     #[options(no_short, meta = "PATH", help = "path to Cargo.toml")]
     manifest_path: Option<PathBuf>,
 
@@ -370,6 +377,7 @@ pub(crate) fn run(args: Vec<String>) {
             &args.cargo_args,
             &cargo_manifest,
             args.bindgen,
+            args.apply_ndk_quote_workaround,
             &out_dir,
         );
         let code = status.code().unwrap_or(-1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,59 +5,12 @@ mod cargo;
 mod cli;
 mod meta;
 
-#[cfg(windows)]
-fn args_hack(cmd: &str) -> anyhow::Result<()> {
-    use std::os::windows::process::CommandExt;
-
-    let args = wargs::command_line_to_argv(None)
-        .skip(1)
-        .collect::<Vec<_>>();
-
-    let mut process = std::process::Command::new(cmd)
-        .raw_arg(args.join(" "))
-        .spawn()?;
-
-    let status = process.wait()?;
-
-    if status.success() {
-        Ok(())
-    } else {
-        Err(anyhow::anyhow!(
-            "Errored with code {}",
-            status.code().unwrap()
-        ))
-    }
-}
-
 fn main() -> anyhow::Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     if env::var("CARGO").is_err() {
         eprintln!("This binary may only be called via `cargo ndk`.");
         exit(1);
-    }
-
-    #[cfg(windows)]
-    {
-        let main_arg = std::env::args().next().unwrap();
-        let main_arg = std::path::Path::new(&main_arg)
-            .file_stem()
-            .unwrap()
-            .to_str()
-            .unwrap();
-
-        if main_arg != "cargo-ndk" {
-            let maybe = main_arg.to_uppercase().replace('-', "_");
-            let app = match std::env::var(format!("CARGO_NDK_{maybe}")) {
-                Ok(cmd) => cmd,
-                Err(err) => {
-                    log::error!("{}", err);
-                    panic!("{}", err);
-                }
-            };
-            log::debug!("Running command: {app}");
-            return args_hack(&app);
-        }
     }
 
     let args = std::env::args().skip(2).collect::<Vec<_>>();


### PR DESCRIPTION
This is an alternative fix for #92 that avoids hitting command line length limitations and avoid needing to use `cargo-ndk` as a spring board for running `clang`, which avoids needing temporary hard links or copying the `cargo-ndk` binary to the target/ directory.

By default cargo-ndk will just emit an error message if it recognises the current NDK needs a quoting workaround, and will also emit a warning suggesting to re-run with
`--apply-ndk-quote-workaround` so that `cargo-ndk` can automatically apply the required workaround.

If `--apply-ndk-quote-workaround` is passed then `cargo ndk` will replace lines matching `if "%1" == "-cc1" goto :L` with `if "%~1" == "-cc1" goto :L` in the CC and CXX `.cmd` files which will avoid any double quotes when checking if the first argument == "-cc1".

Fixes #104