### PR TITLE
Fix: create output dir before canonicalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+- Fix: create output dir before canonicalize
+
 ### v3.5.7 - 2024-08-19
 
 - Fix: canonicalize output directory path for `CARGO_NDK_OUTPUT_PATH`, fixes build scripts not at workspace root 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -586,6 +586,11 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
     let platform = args.platform.unwrap_or(config.platform);
 
     if let Some(output_dir) = args.output_dir.as_ref() {
+        if let Err(e) = fs::create_dir_all(&output_dir) {
+            shell.error(format!("failed to create output dir, {e}"))?;
+            std::process::exit(1);
+        }
+
         // Canonicalize because path is shared with build scripts that can run in a different current_dir.
         let output_dir = match dunce::canonicalize(output_dir) {
             Ok(p) => p,
@@ -598,11 +603,6 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
                 }
             }
         };
-
-        if let Err(e) = fs::create_dir_all(&output_dir) {
-            shell.error(format!("failed to create output dir, {e}"))?;
-            std::process::exit(1);
-        }
 
         shell.verbose(|shell| {
             shell.status_with_color(


### PR DESCRIPTION
Silly bug introduced by me in #140. Canonicalize needs the path to exist.

For the other pull request I only tested in a project that already creates the path and a case where a file already exists in the path (the panic issue). I have now tested with a relative path that does not exist too.