### PR TITLE
Allow specifying message format as an argument

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -314,8 +314,13 @@ pub(crate) fn run(
     cargo_args.push("--target".into());
     cargo_args.push(triple.into());
 
-    cargo_args.push("--message-format".into());
-    cargo_args.push("json-render-diagnostics".into());
+    let print_json_output = check_message_format(&cargo_args);
+
+    // If the user has not set a message format, we set it to json-render-diagnostics
+    if print_json_output == MessageFormat::NotSet {
+        cargo_args.push("--message-format".into());
+        cargo_args.push("json-render-diagnostics".into());
+    }
 
     cargo_cmd.args(&cargo_args);
 
@@ -334,15 +339,103 @@ pub(crate) fn run(
     let mut artifacts = Vec::new();
 
     for msg in Message::parse_stream(reader) {
-        match msg? {
-            Message::CompilerArtifact(artifact) => artifacts.push(artifact),
-            Message::CompilerMessage(msg) => println!("{msg}"),
-            Message::TextLine(line) => println!("{line}"),
-            _ => {}
+        if print_json_output == MessageFormat::Json {
+            println!("{}", serde_json::to_string(&msg?).unwrap());
+        } else {
+            match msg? {
+                Message::CompilerArtifact(artifact) => artifacts.push(artifact),
+                Message::CompilerMessage(msg) => println!("{msg}"),
+                Message::TextLine(line) => println!("{line}"),
+                _ => {}
+            }
         }
     }
 
     let status = child.wait().context("cargo crashed")?;
 
     Ok((status, artifacts))
+}
+
+/// Check if the user has set a message format in the cargo arguments.
+///
+/// If the user has set a message format to json, return MessageFormat::Json.
+/// If the user has set a message format to something else, return MessageFormat::Other.
+/// If the user has not set a message format, return MessageFormat::NotSet.
+fn check_message_format(args: &[OsString]) -> MessageFormat {
+    let mut args_iter = args.iter();
+    while let Some(arg) = args_iter.next() {
+        if let Some(arg_str) = arg.to_str() {
+            if arg_str == "--message-format" {
+                if let Some(next_arg) = args_iter.next() {
+                    if let Some(next_arg_str) = next_arg.to_str() {
+                        return MessageFormat::from_str(next_arg_str);
+                    }
+                }
+            } else if arg_str.starts_with("--message-format") {
+                let splitted_arg: Vec<&str> = arg_str.splitn(2, '=').collect();
+                if splitted_arg.len() == 2 {
+                    return MessageFormat::from_str(splitted_arg[1]);
+                }
+            }
+        }
+    }
+    MessageFormat::NotSet
+}
+
+/// The output format for cargo messages.
+#[derive(Debug, PartialEq)]
+pub enum MessageFormat {
+    /// JSON-output
+    Json,
+
+    /// Any other output format, set by user
+    Other,
+
+    /// Not set by user
+    NotSet,
+}
+
+impl MessageFormat {
+    pub fn from_str(value: &str) -> MessageFormat {
+        match value {
+            "human" | "short" => MessageFormat::Other,
+            "json" | "json-diagnostic-short" | "json-diagnostic-rendered-ansi" => {
+                MessageFormat::Json
+            }
+            "json-render-diagnostics" => MessageFormat::Other,
+            _ => MessageFormat::NotSet,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_check_message_format() {
+        let args = vec![
+            OsString::from("--message-format"),
+            OsString::from("json-render-diagnostics"),
+        ];
+        assert_eq!(check_message_format(&args), MessageFormat::Other);
+
+        let args = vec![OsString::from("--message-format"), OsString::from("human")];
+        assert_eq!(check_message_format(&args), MessageFormat::Other);
+
+        let args = vec![OsString::from("--message-format=json")];
+        assert_eq!(check_message_format(&args), MessageFormat::Json);
+
+        let args = vec![OsString::from("--message-format=json-diagnostic-short")];
+        assert_eq!(check_message_format(&args), MessageFormat::Json);
+
+        let args = vec![
+            OsString::from("--other-arg"),
+            OsString::from("--message-format=json"),
+        ];
+        assert_eq!(check_message_format(&args), MessageFormat::Json);
+
+        let args = vec![OsString::from("--other-arg")];
+        assert_eq!(check_message_format(&args), MessageFormat::NotSet);
+    }
 }


### PR DESCRIPTION
I'm using cargo-ndk as a rust-analyzer.check.overrideCommand in vscode.

As follows
```
cargo ndk check --message-format=json-diagnostic-rendered-ansi --keep-going
```

Currently, if the command would see any errors, the output would be captured and printed human-style.

This merge request checks, if user has overridden the message format. The printout is also selected to be json or formatted, depending on the argument. Based on list at https://doc.rust-lang.org/cargo/commands/cargo-check.html#display-options
