### PR TITLE
Export Android platform vars from ndk-env

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -66,11 +66,14 @@ fn is_64bit(triple: &str) -> bool {
     triple.starts_with("aarch64") || triple.starts_with("x86_64")
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_env(
     triple: &str,
     ndk_home: &Path,
     ndk_version: &Version,
     clang_target: &str,
+    platform: u8,
+    android_abi: &str,
     link_builtins: bool,
     link_cxx_shared: bool,
 ) -> BTreeMap<String, OsString> {
@@ -146,6 +149,12 @@ pub(crate) fn build_env(
             CARGO_NDK_SYSROOT_TARGET_KEY.to_string(),
             cargo_ndk_sysroot_target.into(),
         ),
+        (
+            "CARGO_NDK_ANDROID_PLATFORM".to_string(),
+            platform.to_string().into(),
+        ),
+        ("ANDROID_PLATFORM".to_string(), platform.to_string().into()),
+        ("ANDROID_ABI".to_string(), android_abi.into()),
         // https://github.com/KyleMayes/clang-sys?tab=readme-ov-file#environment-variables
         ("CLANG_PATH".into(), target_cc.clone().into()),
         ("_CARGO_NDK_LINK_TARGET".into(), clang_target.into()), // Recognized by main() so we know when we're acting as a wrapper
@@ -241,6 +250,7 @@ pub(crate) fn run(
     version: &Version,
     triple: &str,
     platform: u8,
+    android_abi: &str,
     link_builtins: bool,
     link_cxx_shared: bool,
     cargo_args: &[String],
@@ -260,6 +270,8 @@ pub(crate) fn run(
         ndk_home,
         version,
         &clang_target,
+        platform,
+        android_abi,
         link_builtins,
         link_cxx_shared,
     );
@@ -299,12 +311,10 @@ pub(crate) fn run(
     let mut cargo_args = cargo_args.to_vec();
 
     match dir.parent() {
-        Some(parent) => {
-            if parent != dir {
-                // log::debug!("Working directory does not match manifest-path");
-                cargo_args.push("--manifest-path".into());
-                cargo_args.push(cargo_manifest.into());
-            }
+        Some(parent) if parent != dir => {
+            // log::debug!("Working directory does not match manifest-path");
+            cargo_args.push("--manifest-path".into());
+            cargo_args.push(cargo_manifest.into());
         }
         _ => {
             // log::warn!("Parent of current working directory does not exist");
@@ -345,4 +355,31 @@ pub(crate) fn run(
     let status = child.wait().context("cargo crashed")?;
 
     Ok((status, artifacts))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use cargo_metadata::semver::Version;
+
+    use super::build_env;
+
+    #[test]
+    fn build_env_exports_android_platform_and_abi() {
+        let env = build_env(
+            "aarch64-linux-android",
+            Path::new("/opt/android-ndk"),
+            &Version::new(28, 0, 0),
+            "--target=aarch64-linux-android28",
+            28,
+            "arm64-v8a",
+            false,
+            false,
+        );
+
+        assert_eq!(env["CARGO_NDK_ANDROID_PLATFORM"], "28");
+        assert_eq!(env["ANDROID_PLATFORM"], "28");
+        assert_eq!(env["ANDROID_ABI"], "arm64-v8a");
+    }
 }

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -60,6 +60,8 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
         &ndk_home,
         &ndk_version,
         &clang_target,
+        args.platform,
+        &args.target.to_string(),
         args.link_builtins,
         args.link_libcxx_shared,
     )

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -654,7 +654,7 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
                 )
             })?;
             unsafe {
-                std::env::set_var("ANDROID_ABI", android_abi);
+                std::env::set_var("ANDROID_ABI", &android_abi);
             }
 
             let (status, artifacts) = crate::cargo::run(
@@ -664,6 +664,7 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
                 &ndk_version,
                 triple,
                 platform,
+                &android_abi,
                 args.link_builtins,
                 args.link_libcxx_shared,
                 &args.cargo_args,
@@ -758,9 +759,15 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
                 .filter(|a| artifact_is_cdylib(a))
                 .filter(|a| a.package_id == current_package_id)
             {
-                let Some(file) = artifact.filenames.iter().find(|name| name.extension() == Some("so"))
+                let Some(file) = artifact
+                    .filenames
+                    .iter()
+                    .find(|name| name.extension() == Some("so"))
                 else {
-                    shell.error(format!("No cdylib file found to copy in\n{:#?}", artifact.filenames))?;
+                    shell.error(format!(
+                        "No cdylib file found to copy in\n{:#?}",
+                        artifact.filenames
+                    ))?;
                     std::process::exit(1);
                 };
                 let dest = arch_output_dir.join(file.file_name().unwrap());

--- a/src/cli/test.rs
+++ b/src/cli/test.rs
@@ -139,6 +139,8 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
         &ndk_home,
         &ndk_version,
         &clang_target,
+        platform,
+        &target.to_string(),
         args.link_builtins,
         args.link_cxx_shared,
     );


### PR DESCRIPTION
Closes bbqsrc/cargo-ndk#198.

`cargo ndk build` already makes `ANDROID_PLATFORM` and `ANDROID_ABI` available to build scripts, but `cargo ndk-env` did not include them in its generated environment. This threads the selected platform and Android ABI through the shared environment builder so `ndk-env`, `ndk-test`, and the normal cargo command path use the same values.

I also added a focused regression test for the generated environment map.

Validation:

- `cargo fmt --all -- --check`
- `cargo test build_env_exports_android_platform_and_abi --locked`
- `cargo test --locked`
- `cargo clippy -- -D warnings`
- `cargo install --locked --path . --root .codex-tmp/cargo-install/cargo-ndk`
- `cargo ndk-env --target arm64-v8a --platform 28 --json` with a project-local fake NDK `source.properties`, checked `ANDROID_PLATFORM=28`, `ANDROID_ABI=arm64-v8a`, and `CARGO_NDK_ANDROID_PLATFORM=28`
- same fake-NDK smoke for default shell export output and `--powershell`
- `git diff --check`
- review-fix-loop: no discrete regression introduced by the patch

