### PR TITLE
Fix beta clippy format borrow warnings

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -13,7 +13,7 @@ use cargo_metadata::{Artifact, Message, semver::Version};
 use crate::{ARCH, clang_target, ndk_tool, shell::Shell, sysroot_suffix, sysroot_target};
 
 fn cargo_env_target_cfg(triple: &str, key: &str) -> String {
-    format!("CARGO_TARGET_{}_{}", &triple.replace('-', "_"), key).to_uppercase()
+    format!("CARGO_TARGET_{}_{}", triple.replace('-', "_"), key).to_uppercase()
 }
 
 #[inline]
@@ -100,7 +100,7 @@ pub(crate) fn build_env(
     let cargo_ar_key = cargo_env_target_cfg(triple, "ar");
     let cargo_linker_key = cargo_env_target_cfg(triple, "linker");
     let cargo_runner_key = cargo_env_target_cfg(triple, "runner");
-    let bindgen_clang_args_key = format!("BINDGEN_EXTRA_CLANG_ARGS_{}", &triple.replace('-', "_"));
+    let bindgen_clang_args_key = format!("BINDGEN_EXTRA_CLANG_ARGS_{}", triple.replace('-', "_"));
 
     let target_cc = ndk_home.join(ndk_tool(ARCH, "clang"));
     let target_cflags = match cflags_value {
@@ -123,8 +123,8 @@ pub(crate) fn build_env(
 
     let extra_include = format!(
         "{}/usr/include/{}",
-        &cargo_ndk_sysroot_path.display(),
-        &cargo_ndk_sysroot_target
+        cargo_ndk_sysroot_path.display(),
+        cargo_ndk_sysroot_target
     );
 
     let mut envs = [
@@ -218,7 +218,7 @@ pub(crate) fn build_env(
 
     let bindgen_args = format!(
         "--sysroot={} -I{}",
-        &cargo_ndk_sysroot_path.display(),
+        cargo_ndk_sysroot_path.display(),
         extra_include
     );
     let bindgen_clang_args = bindgen_args.replace('\\', "/");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -537,7 +537,7 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
     shell.very_verbose(|shell| {
         shell.status_with_color(
             "Exporting",
-            format!("CARGO_NDK_CMAKE_TOOLCHAIN_PATH={:?}", &cmake_toolchain_path),
+            format!("CARGO_NDK_CMAKE_TOOLCHAIN_PATH={:?}", cmake_toolchain_path),
             termcolor::Color::Cyan,
         )
     })?;
@@ -619,12 +619,12 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
         .into_iter()
         .map(|target| {
             let triple = target.triple();
-            shell.status("Building", format!("{} ({})", &target, &triple))?;
+            shell.status("Building", format!("{} ({})", target, triple))?;
 
             shell.very_verbose(|shell| {
                 shell.status_with_color(
                     "Exporting",
-                    format!("CARGO_NDK_ANDROID_PLATFORM={:?}", &target.to_string()),
+                    format!("CARGO_NDK_ANDROID_PLATFORM={:?}", target.to_string()),
                     termcolor::Color::Cyan,
                 )
             })?;
@@ -649,7 +649,7 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
             shell.very_verbose(|shell| {
                 shell.status_with_color(
                     "Exporting",
-                    format!("ANDROID_ABI={:?}", &android_abi),
+                    format!("ANDROID_ABI={:?}", android_abi),
                     termcolor::Color::Cyan,
                 )
             })?;
@@ -737,10 +737,7 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
                     shell.verbose(|shell| shell.status("Fresh", "libc++_shared.so"))?;
                 } else {
                     shell.verbose(|shell| {
-                        shell.status(
-                            "Copying",
-                            format!("libc++_shared.so -> {}", &dest.display()),
-                        )
+                        shell.status("Copying", format!("libc++_shared.so -> {}", dest.display()))
                     })?;
 
                     fs::copy(cargo_ndk_sysroot_libs_path.join("libc++_shared.so"), &dest)
@@ -778,7 +775,7 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
                 }
 
                 shell.verbose(|shell| {
-                    shell.status("Copying", format!("{file} -> {}", &dest.display()))
+                    shell.status("Copying", format!("{file} -> {}", dest.display()))
                 })?;
 
                 fs::copy(file, &dest)

--- a/src/cli/test.rs
+++ b/src/cli/test.rs
@@ -148,7 +148,7 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
     shell.verbose(|shell| {
         shell.status_with_color(
             "Building",
-            format!("test binary for {} ({})", &target, &triple),
+            format!("test binary for {} ({})", target, triple),
             termcolor::Color::Cyan,
         )
     })?;


### PR DESCRIPTION
This follows up on #203 after the `main` push run hit beta/nightly clippy failures:

https://github.com/bbqsrc/cargo-ndk/actions/runs/26822863965

The failing jobs all stop in `cargo clippy -- -D warnings` on `clippy::useless-borrows-in-formatting`. This removes the redundant formatting borrows that current beta/nightly now report as warnings, without changing the formatted values.

Local checks:

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `git diff --check`

Review gate:

- `review-fix-loop` clean: no correctness issues found
