### PR TITLE
Fix ndk-env help output

### DIFF
--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 
 #[derive(Debug, Parser, Clone)]
+#[command(name = "cargo-ndk-env")]
 struct EnvArgs {
     /// Triples for the target. Can be Rust or Android target names (i.e. arm64-v8a)
     #[arg(short, long, env = "CARGO_NDK_TARGET")]
@@ -37,7 +38,7 @@ struct EnvArgs {
 }
 
 pub fn run(args: Vec<String>) -> anyhow::Result<()> {
-    let (mut shell, args) = init(args)?;
+    let (mut shell, args) = init::<EnvArgs>(args)?;
     let args = EnvArgs::try_parse_from(args)?;
 
     let (ndk_home, _ndk_detection_method) = match derive_ndk_path(&mut shell) {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,7 +13,7 @@ use std::{
 
 use anyhow::Context;
 use cargo_metadata::{Artifact, CrateType, MetadataCommand, semver::Version};
-use clap::{CommandFactory, Parser};
+use clap::Parser;
 use filetime::FileTime;
 
 use crate::{
@@ -37,6 +37,7 @@ impl CommandExt for Command {
 }
 
 #[derive(Debug, Parser, Clone)]
+#[command(name = "cargo-ndk")]
 struct BuildArgs {
     /// Triples for the target. Can be Rust or Android target names (i.e. arm64-v8a)
     #[arg(short, long, env = "CARGO_NDK_TARGET", value_delimiter = ',')]
@@ -376,18 +377,21 @@ impl StringVecExt for Vec<String> {
     }
 }
 
-fn init(args: Vec<String>) -> anyhow::Result<(Shell, Vec<String>)> {
+fn init<T>(args: Vec<String>) -> anyhow::Result<(Shell, Vec<String>)>
+where
+    T: clap::CommandFactory,
+{
     if std::env::var_os("CARGO_NDK_NO_PANIC_HOOK").is_none() {
         std::panic::set_hook(Box::new(panic_hook));
     }
 
     if args.contains_str("--help") {
-        BuildArgs::command().print_long_help().unwrap();
+        T::command().print_long_help().unwrap();
         std::process::exit(0);
     }
 
     if args.contains_str("-h") {
-        BuildArgs::command().print_help().unwrap();
+        T::command().print_help().unwrap();
         std::process::exit(0);
     }
 
@@ -435,7 +439,7 @@ fn init(args: Vec<String>) -> anyhow::Result<(Shell, Vec<String>)> {
 
 pub fn run(args: Vec<String>) -> anyhow::Result<()> {
     // Check for help/version before parsing to avoid required arg errors
-    let (mut shell, args) = init(args)?;
+    let (mut shell, args) = init::<BuildArgs>(args)?;
 
     let args = match parse_mixed_args::<BuildArgs>(args) {
         Ok(args) => args,

--- a/src/cli/test.rs
+++ b/src/cli/test.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 #[derive(Debug, Parser, Clone)]
+#[command(name = "cargo-ndk-test")]
 struct TestArgs {
     /// Triples for the target. Can be Rust or Android target names (i.e. arm64-v8a)
     #[arg(short, long, env = "CARGO_NDK_TARGET")]
@@ -56,7 +57,7 @@ impl HasCargoArgs for TestArgs {
 pub fn run(args: Vec<String>) -> anyhow::Result<()> {
     // Check for help/version before parsing to avoid required arg errors
     let valid_args = args.split(|x| x == "--").next().unwrap_or(&args).to_vec();
-    let (mut shell, _) = init(valid_args)?;
+    let (mut shell, _) = init::<TestArgs>(valid_args)?;
 
     let mut args = match TestArgs::try_parse_from(&args) {
         Ok(args) => args,

--- a/tests/cli_help.rs
+++ b/tests/cli_help.rs
@@ -1,0 +1,30 @@
+use std::process::Command;
+
+fn cargo_ndk_env_help(args: &[&str]) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-ndk-env"))
+        .env("CARGO", "cargo")
+        .args(args)
+        .output()
+        .expect("cargo-ndk-env should run");
+
+    assert!(
+        output.status.success(),
+        "cargo-ndk-env exited with {:?}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8(output.stdout).expect("help output should be valid UTF-8")
+}
+
+#[test]
+fn cargo_ndk_env_help_shows_env_format_options() {
+    for args in [["--help"].as_slice(), ["--", "--help"].as_slice()] {
+        let help = cargo_ndk_env_help(args);
+
+        assert!(help.contains("Usage: cargo-ndk-env"));
+        assert!(help.contains("--powershell"));
+        assert!(help.contains("--json"));
+        assert!(!help.contains("--output-dir"));
+    }
+}


### PR DESCRIPTION
Fixes #195.

`cargo-ndk-env` was using the shared build command when handling early help flags, so `cargo ndk-env -- --help` showed build options instead of env output options like `--json` and `--powershell`. This changes the shared early-help path to print the command for the active binary and adds regression coverage for both `--help` and `-- --help`.

Verification:
- `cargo fmt --all -- --check`
- `cargo test --test cli_help --locked`
- `cargo test --locked`
- `cargo clippy -- -D warnings`
- `CARGO=1 cargo run --quiet --bin cargo-ndk-env -- --help`
- `CARGO=1 cargo run --quiet --bin cargo-ndk-env -- -- --help`
- `git diff --check HEAD~1..HEAD`
- project-local review-fix-loop completed with no actionable findings