### PR TITLE
Export detected NDK version in ndk-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ These environment variables are exported for use in build scripts and other down
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `CARGO_NDK_ANDROID_PLATFORM` | The Android platform API number as an integer | `21` |
+| `CARGO_NDK_NDK_VERSION` | The detected Android NDK revision | `28.0.12433566` |
 | `CARGO_NDK_OUTPUT_PATH` | The output path as specified with the `-o` flag | `./jniLibs` |
 | `CARGO_NDK_SYSROOT_PATH` | Path to the sysroot inside the Android NDK | `/path/to/ndk/toolchains/llvm/prebuilt/...` |
 | `CARGO_NDK_SYSROOT_TARGET` | The target name for files inside the sysroot (differs from LLVM triples) | `aarch64-linux-android` |

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -61,6 +61,7 @@ fn clang_lib_path(ndk_home: &Path) -> PathBuf {
 const CARGO_NDK_SYSROOT_PATH_KEY: &str = "CARGO_NDK_SYSROOT_PATH";
 const CARGO_NDK_SYSROOT_TARGET_KEY: &str = "CARGO_NDK_SYSROOT_TARGET";
 const CARGO_NDK_SYSROOT_LIBS_PATH_KEY: &str = "CARGO_NDK_SYSROOT_LIBS_PATH";
+const CARGO_NDK_NDK_VERSION_KEY: &str = "CARGO_NDK_NDK_VERSION";
 
 fn is_64bit(triple: &str) -> bool {
     triple.starts_with("aarch64") || triple.starts_with("x86_64")
@@ -152,6 +153,10 @@ pub(crate) fn build_env(
         (
             "CARGO_NDK_ANDROID_PLATFORM".to_string(),
             platform.to_string().into(),
+        ),
+        (
+            CARGO_NDK_NDK_VERSION_KEY.to_string(),
+            ndk_version.to_string().into(),
         ),
         ("ANDROID_PLATFORM".to_string(), platform.to_string().into()),
         ("ANDROID_ABI".to_string(), android_abi.into()),
@@ -379,6 +384,7 @@ mod tests {
         );
 
         assert_eq!(env["CARGO_NDK_ANDROID_PLATFORM"], "28");
+        assert_eq!(env["CARGO_NDK_NDK_VERSION"], "28.0.0");
         assert_eq!(env["ANDROID_PLATFORM"], "28");
         assert_eq!(env["ANDROID_ABI"], "arm64-v8a");
     }


### PR DESCRIPTION
Fixes #192.

This exposes the already parsed Android NDK revision through the generated `cargo ndk-env` environment output as `CARGO_NDK_NDK_VERSION`, so shell, PowerShell, and JSON consumers can read the detected revision without parsing the NDK path.

I also documented the new variable in the README and extended the existing `build_env` export test.

Verification:
- `cargo fmt --all -- --check`
- `cargo test cargo::tests --locked`
- `cargo test --locked`
- `cargo clippy -- -D warnings`
- `git diff --check`