### PR TITLE
Print NDK revision for verbose ndk-env

### DIFF
--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -34,13 +34,21 @@ struct EnvArgs {
     /// Print output in JSON format
     #[arg(long)]
     json: bool,
+
+    /// Use verbose output
+    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count)]
+    _verbose: u8,
+
+    /// Do not print status output
+    #[arg(short = 'q', long = "quiet")]
+    _quiet: bool,
 }
 
 pub fn run(args: Vec<String>) -> anyhow::Result<()> {
     let (mut shell, args) = init(args)?;
     let args = EnvArgs::try_parse_from(args)?;
 
-    let (ndk_home, _ndk_detection_method) = match derive_ndk_path(&mut shell) {
+    let (ndk_home, ndk_detection_method) = match derive_ndk_path(&mut shell) {
         Some((path, method)) => (path, method),
         None => {
             shell.error("Could not find any NDK.")?;
@@ -52,6 +60,19 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
     };
 
     let ndk_version = derive_ndk_version(&ndk_home)?;
+    shell.verbose(|shell| {
+        shell.status_with_color(
+            "Detected",
+            format!(
+                "NDK v{} ({}) [{}]",
+                ndk_version,
+                ndk_home.display(),
+                ndk_detection_method
+            ),
+            termcolor::Color::Cyan,
+        )
+    })?;
+
     let clang_target = clang_target(args.target.triple(), args.platform);
 
     // Try command line, then config. Config falls back to defaults in any case.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -396,7 +396,7 @@ fn init(args: Vec<String>) -> anyhow::Result<(Shell, Vec<String>)> {
         std::process::exit(0);
     }
 
-    let verbosity = if args.contains_str("-q") {
+    let verbosity = if args.contains_str("-q") || args.contains_str("--quiet") {
         Verbosity::Quiet
     } else if args.contains_str("-vv") {
         Verbosity::VeryVerbose


### PR DESCRIPTION
Related to #192; this is the verbose-output side, separate from #207's env-var export.

`cargo ndk` already reports the detected NDK revision in verbose output, and `cargo ndk-env` uses the same NDK detection path but did not surface it. This adds accepted `-v` / `--verbose` and `-q` / `--quiet` flags to `ndk-env`, then prints the detected NDK revision/path on stderr in verbose mode so shell exports and JSON stdout stay clean by default.

Validation:
- `cargo fmt --all -- --check`
- `git diff --check`
- fake-NDK smoke checks for default JSON output, `-v` stderr detection output, and `--quiet --verbose` suppression
- `cargo test --locked`
- `cargo clippy -- -D warnings`
- review-fix-loop: clean (`I did not find any actionable correctness issues`)
