### PR TITLE
feat(library): expose embeddable Android NDK configuration API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This cargo extension handles all the environment configuration needed for succes
 - [Installing](#installing)
 - [Examples](#examples)
   - [Building a library for 32-bit and 64-bit ARM systems](#building-a-library-for-32-bit-and-64-bit-arm-systems)
+- [Using cargo-ndk as a library](#using-cargo-ndk-as-a-library)
 - [Usage](#usage)
   - [Using `cargo run` binaries via adb](#using-cargo-run-binaries-via-adb)
   - [Running your tests on an Android device](#running-your-tests-on-an-android-device)
@@ -70,6 +71,54 @@ This specifies the Android targets to be built (ordinary triples are also suppor
 expected by Android, and then the ordinary flags to be passed to `cargo`.
 
 ![Example](./example/example.svg)
+
+## Using `cargo-ndk` as a library
+
+Build tools such as an `xtask` can depend on `cargo-ndk` directly and keep
+ownership of the Cargo process. The configuration below makes the current
+`xtask` executable the linker wrapper, so no separate `cargo-ndk` executable is
+needed beside it:
+
+```toml
+[dependencies]
+cargo-ndk = "4"
+```
+
+```rust,no_run
+use std::process::Command;
+
+use cargo_ndk::{AndroidTarget, ApiLevel, BuildConfig, Ndk};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Put this before the normal xtask dispatch. Cargo invokes the same
+    // executable again when it needs to link the Android target.
+    if std::env::var_os("_CARGO_NDK_LINK_TARGET").is_some() {
+        let status = cargo_ndk::run_linker_wrapper()?;
+        std::process::exit(status.code().unwrap_or(1));
+    }
+
+    let ndk = Ndk::discover()?
+        .ok_or_else(|| std::io::Error::other("Android NDK was not found"))?;
+    let target = AndroidTarget::Arm64V8a;
+    let config = BuildConfig::new(ndk, target, ApiLevel::new(28));
+
+    let mut cargo = Command::new("cargo");
+    cargo.args(["build", "--target", target.triple()]);
+    config.configure_command(&mut cargo)?;
+    let status = cargo.status()?;
+    if !status.success() {
+        return Err(format!("cargo exited with {status}").into());
+    }
+
+    Ok(())
+}
+```
+
+`BuildConfig` only adapts Cargo to the Android NDK; the caller still chooses
+the Cargo command and owns its process lifecycle. Add
+`.with_runner(...)` when the Cargo command also needs a target runner.
+Configurations for NDK releases older than r23 return an error; the CLI then
+formats that error according to its normal output policy.
 
 ## Usage
 
@@ -126,6 +175,7 @@ These environment variables are exported for use in build scripts and other down
 | `CARGO_NDK_SYSROOT_PATH` | Path to the sysroot inside the Android NDK | `/path/to/ndk/toolchains/llvm/prebuilt/...` |
 | `CARGO_NDK_SYSROOT_TARGET` | The target name for files inside the sysroot (differs from LLVM triples) | `aarch64-linux-android` |
 | `CARGO_NDK_SYSROOT_LIBS_PATH` | Path to libraries in sysroot with target (`$CARGO_NDK_SYSROOT_PATH/usr/lib/$CARGO_NDK_SYSROOT_TARGET`) | `/path/to/ndk/.../usr/lib/aarch64-linux-android` |
+| `CARGO_NDK_CMAKE_TOOLCHAIN_PATH` | Path to the NDK CMake toolchain file | `/path/to/ndk/build/cmake/android.toolchain.cmake` |
 | `LIBCLANG_PATH` | Path containing the NDK's libclang shared library, when detected | `/path/to/ndk/toolchains/llvm/prebuilt/.../lib` |
 | `ANDROID_PLATFORM` | The platform version being used | `21` |
 | `ANDROID_ABI` | The Android ABI name | `armeabi-v7a` |
@@ -151,6 +201,8 @@ cargo ndk-env --powershell | Invoke-Expression
 Rust Analyzer and anything else with JSON-based environment handling:
 
 For configuring rust-analyzer, add the `--json` flag and paste the blob into the relevant place in the config.
+The generated environment also includes `CARGO_NDK_CMAKE_TOOLCHAIN_PATH` for
+build scripts that need the NDK CMake toolchain file.
 
 By default, `cargo ndk-env` omits cargo-ndk's internal linker wrapper variables from its output. If you want to source
 the generated environment and then build directly with Cargo using the exported linker configuration, add

--- a/examples/embedding.rs
+++ b/examples/embedding.rs
@@ -1,0 +1,10 @@
+use std::process::exit;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if std::env::var_os("_CARGO_NDK_LINK_TARGET").is_some() {
+        let status = cargo_ndk::run_linker_wrapper()?;
+        exit(status.code().unwrap_or(1));
+    }
+
+    Ok(())
+}

--- a/src/bin/cargo-ndk.rs
+++ b/src/bin/cargo-ndk.rs
@@ -1,56 +1,24 @@
 use std::env;
 use std::process::exit;
 
-/// We are avoiding using the Clang wrapper scripts in the NDK because they have
-/// a quoting bug on Windows (https://github.com/android/ndk/issues/1856) and
-/// for consistency on other platforms, considering it's now generally
-/// recommended to avoid relying on these wrappers:
-/// https://android-review.googlesource.com/c/platform/ndk/+/2134712
-///
-/// Instead; we set cargo-ndk up as our rustc `_LINKER` as a way to be able to pass
-/// --target=<triple><api-level>
-///
-/// We do it this way because we can't modify rustflags before running `cargo
-/// build` without potentially trampling over flags that are configured via
-/// Cargo.
-fn clang_linker_wrapper() -> ! {
-    let args = std::env::args_os().skip(1);
-
-    let clang = std::env::var("_CARGO_NDK_LINK_CLANG")
-        .expect("cargo-ndk rustc linker: didn't find _CARGO_NDK_LINK_CLANG env var");
-    let target = std::env::var("_CARGO_NDK_LINK_TARGET")
-        .expect("cargo-ndk rustc linker: didn't find _CARGO_NDK_LINK_TARGET env var");
-
-    let mut cmd = std::process::Command::new(&clang);
-    cmd.arg(target);
-
-    if let Ok(builtins_path) = std::env::var("_CARGO_NDK_LDFLAGS") {
-        cmd.args(builtins_path.split("\x1f"));
+fn main() -> anyhow::Result<()> {
+    if env::var_os("_CARGO_NDK_LINK_TARGET").is_some() {
+        let status = match cargo_ndk::run_linker_wrapper() {
+            Ok(status) => status,
+            Err(error) => {
+                eprintln!("{error:#}");
+                exit(1);
+            }
+        };
+        exit(status.code().unwrap_or(1));
     }
 
-    let mut child = cmd.args(args).spawn().unwrap_or_else(|err| {
-        eprintln!("cargo-ndk: Failed to spawn {clang:?} as linker: {err}");
-        std::process::exit(1)
-    });
-    let status = child.wait().unwrap_or_else(|err| {
-        eprintln!("cargo-ndk (as linker): Failed to wait for {clang:?} to complete: {err}");
-        std::process::exit(1);
-    });
-
-    std::process::exit(status.code().unwrap_or(1))
-}
-
-fn main() -> anyhow::Result<()> {
     if env::var("CARGO").is_err() {
         eprintln!("This binary may only be called via `cargo ndk`.");
         exit(1);
     }
 
-    if std::env::var("_CARGO_NDK_LINK_TARGET").is_ok() {
-        clang_linker_wrapper();
-    }
-
-    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let args = env::args().skip(1).collect::<Vec<_>>();
 
     cargo_ndk::cli::run(args)
 }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,16 +1,16 @@
 use std::{
     collections::BTreeMap,
     env,
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     io::BufReader,
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
 use anyhow::{Context, Result};
-use cargo_metadata::{Artifact, Message, semver::Version};
+use cargo_metadata::{Artifact, Message};
 
-use crate::{ARCH, clang_target, ndk_tool, shell::Shell, sysroot_suffix, sysroot_target};
+use crate::{ApiLevel, Target, ndk::Ndk, shell::Shell};
 
 fn cargo_env_target_cfg(triple: &str, key: &str) -> String {
     format!("CARGO_TARGET_{}_{}", triple.replace('-', "_"), key).to_uppercase()
@@ -36,26 +36,26 @@ fn cc_env(var_base: &str, triple: &str) -> (String, Option<String>) {
 
 // {}/toolchains/llvm/prebuilt/{ARCH}/lib/clang/{clang_version}/lib/linux
 #[inline]
-fn clang_lib_path(ndk_home: &Path) -> PathBuf {
+fn clang_lib_path(ndk_home: &Path) -> Result<PathBuf> {
     let clang_folder: PathBuf = ndk_home
         .join("toolchains")
         .join("llvm")
         .join("prebuilt")
-        .join(ARCH)
+        .join(crate::ARCH)
         .join("lib")
         .join("clang");
 
     let clang_lib_version = std::fs::read_dir(&clang_folder)
-        .expect("Unable to get clang target directory")
+        .context("unable to get clang target directory")?
         .filter_map(|a| a.ok())
         .max_by(|a, b| a.file_name().cmp(&b.file_name()))
-        .expect("Unable to get clang target")
+        .context("unable to get clang target")?
         .path();
 
-    clang_folder
+    Ok(clang_folder
         .join(clang_lib_version)
         .join("lib")
-        .join("linux")
+        .join("linux"))
 }
 
 #[inline]
@@ -87,7 +87,7 @@ fn libclang_path_with_suffixes(ndk_home: &Path, suffixes: &[&str]) -> Option<Pat
         .join("toolchains")
         .join("llvm")
         .join("prebuilt")
-        .join(ARCH);
+        .join(crate::ARCH);
 
     suffixes
         .iter()
@@ -104,32 +104,133 @@ const CARGO_NDK_SYSROOT_PATH_KEY: &str = "CARGO_NDK_SYSROOT_PATH";
 const CARGO_NDK_SYSROOT_TARGET_KEY: &str = "CARGO_NDK_SYSROOT_TARGET";
 const CARGO_NDK_SYSROOT_LIBS_PATH_KEY: &str = "CARGO_NDK_SYSROOT_LIBS_PATH";
 const CARGO_NDK_NDK_VERSION_KEY: &str = "CARGO_NDK_NDK_VERSION";
+const CARGO_NDK_CMAKE_TOOLCHAIN_PATH_KEY: &str = "CARGO_NDK_CMAKE_TOOLCHAIN_PATH";
 
-fn is_64bit(triple: &str) -> bool {
-    triple.starts_with("aarch64") || triple.starts_with("x86_64")
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn build_env(
-    triple: &str,
-    ndk_home: &Path,
-    ndk_version: &Version,
-    clang_target: &str,
-    platform: u8,
-    android_abi: &str,
+/// Configuration for adapting a Cargo command to an Android NDK toolchain.
+///
+/// The default linker is the current executable. This makes an executable
+/// embedding `cargo-ndk` able to act as its own linker wrapper by dispatching
+/// linker invocations to [`crate::run_linker_wrapper`]. Use [`Self::with_linker`]
+/// when the wrapper lives in a different executable.
+#[derive(Debug, Clone)]
+pub struct BuildConfig {
+    ndk: Ndk,
+    target: Target,
+    api_level: ApiLevel,
+    linker: Option<PathBuf>,
+    runner: Option<PathBuf>,
     link_builtins: bool,
     link_cxx_shared: bool,
-) -> BTreeMap<String, OsString> {
-    let cargo_ndk_path = dunce::canonicalize(env::args().next().unwrap())
-        .expect("Failed to canonicalize absolute path to cargo-ndk")
-        .parent()
-        .unwrap()
-        .join("cargo-ndk");
-    let cargo_ndk_runner_path = dunce::canonicalize(env::args().next().unwrap())
-        .expect("Failed to canonicalize absolute path to cargo-ndk-runner")
-        .parent()
-        .unwrap()
-        .join("cargo-ndk-runner");
+}
+
+impl BuildConfig {
+    /// Creates a build configuration for one Android target.
+    pub fn new(ndk: Ndk, target: Target, api_level: impl Into<ApiLevel>) -> Self {
+        Self {
+            ndk,
+            target,
+            api_level: api_level.into(),
+            linker: None,
+            runner: None,
+            link_builtins: false,
+            link_cxx_shared: false,
+        }
+    }
+
+    /// Sets the executable Cargo should invoke as the target linker.
+    pub fn with_linker(mut self, linker: impl Into<PathBuf>) -> Self {
+        self.linker = Some(linker.into());
+        self
+    }
+
+    /// Sets an optional Cargo target runner, for example an adb-based runner.
+    pub fn with_runner(mut self, runner: impl Into<PathBuf>) -> Self {
+        self.runner = Some(runner.into());
+        self
+    }
+
+    /// Enables linking compiler builtins from the NDK.
+    pub fn with_link_builtins(mut self, enabled: bool) -> Self {
+        self.link_builtins = enabled;
+        self
+    }
+
+    /// Enables linking `libc++_shared`.
+    pub fn with_link_cxx_shared(mut self, enabled: bool) -> Self {
+        self.link_cxx_shared = enabled;
+        self
+    }
+
+    /// Returns the generated environment without starting Cargo.
+    pub fn environment(&self) -> Result<BuildEnvironment> {
+        build_environment(self)
+    }
+
+    /// Applies the NDK environment to a Cargo command.
+    pub fn configure_command(&self, command: &mut Command) -> Result<()> {
+        self.environment()?.apply_to(command);
+        Ok(())
+    }
+
+    /// Returns the target selected by this configuration.
+    pub fn target(&self) -> Target {
+        self.target
+    }
+
+    /// Returns the Android API level selected by this configuration.
+    pub fn api_level(&self) -> ApiLevel {
+        self.api_level
+    }
+
+    /// Returns the NDK used by this configuration.
+    pub fn ndk(&self) -> &Ndk {
+        &self.ndk
+    }
+}
+
+/// Environment variables generated for one Android Cargo build.
+#[derive(Debug, Clone)]
+pub struct BuildEnvironment {
+    variables: BTreeMap<String, OsString>,
+}
+
+impl BuildEnvironment {
+    /// Gets a generated value by environment variable name.
+    pub fn get(&self, key: &str) -> Option<&OsStr> {
+        self.variables.get(key).map(OsString::as_os_str)
+    }
+
+    /// Iterates over generated environment variables without exposing storage ownership.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &OsStr)> {
+        self.variables
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_os_str()))
+    }
+
+    /// Applies all generated variables to a command.
+    pub fn apply_to(&self, command: &mut Command) {
+        for (key, value) in &self.variables {
+            command.env(key, value);
+        }
+    }
+
+    pub(crate) fn into_map(self) -> BTreeMap<String, OsString> {
+        self.variables
+    }
+}
+
+fn build_environment(config: &BuildConfig) -> Result<BuildEnvironment> {
+    config.ndk.ensure_supported()?;
+
+    let ndk_home = config.ndk.path();
+    let ndk_version = config.ndk.version();
+    let target = config.target;
+    let triple = target.triple();
+    let clang_target = target.clang_target(config.api_level);
+    let linker = match &config.linker {
+        Some(linker) => linker.clone(),
+        None => env::current_exe().context("failed to resolve the current executable")?,
+    };
 
     // Environment variables for the `cc` crate
     let (cc_key, _) = cc_env("CC", triple);
@@ -142,27 +243,26 @@ pub(crate) fn build_env(
     // Environment variables for cargo
     let cargo_ar_key = cargo_env_target_cfg(triple, "ar");
     let cargo_linker_key = cargo_env_target_cfg(triple, "linker");
-    let cargo_runner_key = cargo_env_target_cfg(triple, "runner");
     let bindgen_clang_args_key = format!("BINDGEN_EXTRA_CLANG_ARGS_{}", triple.replace('-', "_"));
 
-    let target_cc = ndk_home.join(ndk_tool(ARCH, "clang"));
+    let target_cc = config.ndk.tool("clang");
     let target_cflags = match cflags_value {
         Some(v) => format!("{clang_target} {v}"),
         None => clang_target.to_string(),
     };
-    let target_cxx = ndk_home.join(ndk_tool(ARCH, "clang++"));
+    let target_cxx = config.ndk.tool("clang++");
     let target_cxxflags = match cxxflags_value {
         Some(v) => format!("{clang_target} {v}"),
         None => clang_target.to_string(),
     };
-    let cargo_ndk_sysroot_path = ndk_home.join(sysroot_suffix(ARCH));
-    let cargo_ndk_sysroot_target = sysroot_target(triple);
+    let cargo_ndk_sysroot_path = config.ndk.sysroot();
+    let cargo_ndk_sysroot_target = target.sysroot_target();
     let cargo_ndk_sysroot_libs_path = cargo_ndk_sysroot_path
         .join("usr")
         .join("lib")
         .join(cargo_ndk_sysroot_target);
-    let target_ar = ndk_home.join(ndk_tool(ARCH, "llvm-ar"));
-    let target_ranlib = ndk_home.join(ndk_tool(ARCH, "llvm-ranlib"));
+    let target_ar = config.ndk.tool("llvm-ar");
+    let target_ranlib = config.ndk.tool("llvm-ranlib");
 
     let extra_include = format!(
         "{}/usr/include/{}",
@@ -178,8 +278,7 @@ pub(crate) fn build_env(
         (ar_key, target_ar.clone().into()),
         (ranlib_key, target_ranlib.into_os_string()),
         (cargo_ar_key, target_ar.into_os_string()),
-        (cargo_linker_key, cargo_ndk_path.into_os_string()),
-        (cargo_runner_key, cargo_ndk_runner_path.into_os_string()),
+        (cargo_linker_key, linker.into_os_string()),
         (
             CARGO_NDK_SYSROOT_PATH_KEY.to_string(),
             cargo_ndk_sysroot_path.clone().into_os_string(),
@@ -194,14 +293,21 @@ pub(crate) fn build_env(
         ),
         (
             "CARGO_NDK_ANDROID_PLATFORM".to_string(),
-            platform.to_string().into(),
+            config.api_level.to_string().into(),
         ),
         (
             CARGO_NDK_NDK_VERSION_KEY.to_string(),
             ndk_version.to_string().into(),
         ),
-        ("ANDROID_PLATFORM".to_string(), platform.to_string().into()),
-        ("ANDROID_ABI".to_string(), android_abi.into()),
+        (
+            CARGO_NDK_CMAKE_TOOLCHAIN_PATH_KEY.to_string(),
+            config.ndk.cmake_toolchain_path().into_os_string(),
+        ),
+        (
+            "ANDROID_PLATFORM".to_string(),
+            config.api_level.to_string().into(),
+        ),
+        ("ANDROID_ABI".to_string(), target.abi().into()),
         // https://github.com/KyleMayes/clang-sys?tab=readme-ov-file#environment-variables
         ("CLANG_PATH".into(), target_cc.clone().into()),
         ("_CARGO_NDK_LINK_TARGET".into(), clang_target.into()), // Recognized by main() so we know when we're acting as a wrapper
@@ -209,6 +315,13 @@ pub(crate) fn build_env(
     ]
     .into_iter()
     .collect::<BTreeMap<String, OsString>>();
+
+    if let Some(runner) = &config.runner {
+        envs.insert(
+            cargo_env_target_cfg(triple, "runner"),
+            runner.clone().into_os_string(),
+        );
+    }
 
     if let Some(path) = libclang_path(ndk_home) {
         envs.insert("LIBCLANG_PATH".to_string(), path.into_os_string());
@@ -224,28 +337,28 @@ pub(crate) fn build_env(
 
     let mut ldflags = vec![];
 
-    if link_builtins {
-        let builtins_path = clang_lib_path(ndk_home);
+    if config.link_builtins {
+        let builtins_path = clang_lib_path(ndk_home)?;
 
         ldflags.push(format!("-L{}", builtins_path.display()));
         ldflags.push(format!(
             "-lclang_rt.builtins-{}-android",
-            sysroot_target(triple).split('-').next().unwrap()
+            target.sysroot_target().split('-').next().unwrap()
         ));
     }
 
-    if link_cxx_shared {
+    if config.link_cxx_shared {
         ldflags.push("-lc++_shared".to_string());
     }
 
     // 64-bit android requires 16kb pages now. It is the default for NDK r28+.
     // https://developer.android.com/guide/practices/page-sizes
-    if is_64bit(triple) {
-        if ndk_version.major <= 27 {
+    if target.is_64_bit() {
+        if ndk_version.major() <= 27 {
             ldflags.push("-Wl,-z,max-page-size=16384".to_string());
         }
 
-        if ndk_version.major <= 22 {
+        if ndk_version.major() <= 22 {
             ldflags.push("-Wl,-z,common-page-size=16384".to_string());
         }
     }
@@ -279,13 +392,13 @@ pub(crate) fn build_env(
         bindgen_clang_args.into(),
     );
 
-    envs
+    Ok(BuildEnvironment { variables: envs })
 }
 
 /// Note: considering that there is an upstream quoting bug in the clang .cmd
 /// wrappers on Windows we intentionally avoid any wrapper scripts and
 /// instead pass a `--target=<triple><api_level>` argument to clang by using
-/// cargo-ndk itself as a linker wrapper.
+/// the configured executable as a linker wrapper.
 ///
 /// See: https://github.com/android/ndk/issues/1856
 ///
@@ -297,35 +410,32 @@ pub(crate) fn build_env(
 pub(crate) fn run(
     shell: &mut Shell,
     dir: &Path,
-    ndk_home: &Path,
-    version: &Version,
-    triple: &str,
+    ndk: &Ndk,
+    target: Target,
     platform: u8,
-    android_abi: &str,
+    linker: &Path,
+    runner: &Path,
     link_builtins: bool,
     link_cxx_shared: bool,
     cargo_args: &[String],
     cargo_manifest: &Path,
 ) -> Result<(std::process::ExitStatus, Vec<Artifact>)> {
-    if version.major < 23 {
-        shell.error("NDK versions less than r23 are not supported. Install an up-to-date version of the NDK.").unwrap();
-        std::process::exit(1);
-    }
-
     let cargo_args: Vec<OsString> = cargo_args.iter().map(Into::into).collect();
-    let clang_target = clang_target(triple, platform);
+    let triple = target.triple();
     let cargo_bin = env::var("CARGO").unwrap_or_else(|_| "cargo".into());
     let mut cargo_cmd = Command::new(&cargo_bin);
-    let envs = build_env(
-        triple,
-        ndk_home,
-        version,
-        &clang_target,
-        platform,
-        android_abi,
-        link_builtins,
-        link_cxx_shared,
-    );
+    let config = BuildConfig::new(ndk.clone(), target, ApiLevel::new(platform))
+        .with_linker(linker.to_path_buf())
+        .with_runner(runner.to_path_buf())
+        .with_link_builtins(link_builtins)
+        .with_link_cxx_shared(link_cxx_shared);
+    let envs = match config.environment() {
+        Ok(envs) => envs,
+        Err(error) => {
+            shell.error(error)?;
+            std::process::exit(1);
+        }
+    };
 
     shell
         .very_verbose(|shell| {
@@ -345,7 +455,8 @@ pub(crate) fn run(
         })
         .unwrap();
 
-    cargo_cmd.current_dir(dir).envs(envs);
+    cargo_cmd.current_dir(dir);
+    envs.apply_to(&mut cargo_cmd);
 
     let cargo_args = if !cargo_args.is_empty() && cargo_args[0].as_os_str() == "--" {
         &cargo_args[1..]
@@ -417,19 +528,16 @@ fn append_target_args(
 #[cfg(test)]
 mod tests {
     use std::{
-        ffi::OsString,
+        ffi::{OsStr, OsString},
         fs,
         path::{Path, PathBuf},
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    use cargo_metadata::semver::Version;
-
-    use crate::ARCH;
+    use crate::{ARCH, ApiLevel, BuildConfig, Ndk, Target};
 
     use super::{
-        append_target_args, build_env, libclang_path, libclang_path_with_suffixes,
-        libclang_search_suffixes,
+        append_target_args, libclang_path, libclang_path_with_suffixes, libclang_search_suffixes,
     };
 
     fn temp_ndk_path(name: &str) -> PathBuf {
@@ -454,23 +562,36 @@ mod tests {
         path
     }
 
+    fn create_ndk(ndk_home: &Path) -> Ndk {
+        fs::create_dir_all(ndk_home).expect("failed to create fake NDK directory");
+        fs::write(
+            ndk_home.join("source.properties"),
+            "Pkg.Revision = 28.0.12433566\n",
+        )
+        .expect("failed to write fake NDK metadata");
+        Ndk::from_path(ndk_home).expect("fake NDK should load")
+    }
+
     #[test]
     fn build_env_exports_android_platform_and_abi() {
-        let env = build_env(
-            "aarch64-linux-android",
-            Path::new("/opt/android-ndk"),
-            &Version::new(28, 0, 0),
-            "--target=aarch64-linux-android28",
-            28,
-            "arm64-v8a",
-            false,
-            false,
-        );
+        let ndk_home = temp_ndk_path("build-env-platform");
+        let env = BuildConfig::new(create_ndk(&ndk_home), Target::Arm64V8a, ApiLevel::new(28))
+            .with_linker("/cargo-ndk")
+            .environment()
+            .expect("environment should be generated");
 
-        assert_eq!(env["CARGO_NDK_ANDROID_PLATFORM"], "28");
-        assert_eq!(env["CARGO_NDK_NDK_VERSION"], "28.0.0");
-        assert_eq!(env["ANDROID_PLATFORM"], "28");
-        assert_eq!(env["ANDROID_ABI"], "arm64-v8a");
+        assert_eq!(
+            env.get("CARGO_NDK_ANDROID_PLATFORM"),
+            Some(OsStr::new("28"))
+        );
+        assert_eq!(
+            env.get("CARGO_NDK_NDK_VERSION"),
+            Some(OsStr::new("28.0.12433566"))
+        );
+        assert_eq!(env.get("ANDROID_PLATFORM"), Some(OsStr::new("28")));
+        assert_eq!(env.get("ANDROID_ABI"), Some(OsStr::new("arm64-v8a")));
+
+        fs::remove_dir_all(ndk_home).ok();
     }
 
     #[test]
@@ -527,7 +648,7 @@ mod tests {
         let host_path = create_libclang_file(&ndk_home, "lib");
         let _fallback_path = create_libclang_file(&ndk_home, "musl/lib");
 
-        assert_eq!(libclang_path(&ndk_home), Some(host_path));
+        assert_eq!(libclang_path(&ndk_home).unwrap(), host_path);
 
         fs::remove_dir_all(ndk_home).ok();
     }
@@ -551,7 +672,7 @@ mod tests {
         let ndk_home = temp_ndk_path("lib64-libclang");
         let fallback_path = create_libclang_file(&ndk_home, "lib64");
 
-        assert_eq!(libclang_path(&ndk_home), Some(fallback_path));
+        assert_eq!(libclang_path(&ndk_home).unwrap(), fallback_path);
 
         fs::remove_dir_all(ndk_home).ok();
     }
@@ -561,7 +682,7 @@ mod tests {
         let ndk_home = temp_ndk_path("musl-libclang");
         let fallback_path = create_libclang_file(&ndk_home, "musl/lib");
 
-        assert_eq!(libclang_path(&ndk_home), Some(fallback_path));
+        assert_eq!(libclang_path(&ndk_home).unwrap(), fallback_path);
 
         fs::remove_dir_all(ndk_home).ok();
     }
@@ -580,20 +701,18 @@ mod tests {
     #[test]
     fn build_env_exports_libclang_path_when_detected() {
         let ndk_home = temp_ndk_path("build-env-libclang");
+        let ndk = create_ndk(&ndk_home);
         let libclang_path = create_libclang_file(&ndk_home, "musl/lib");
 
-        let env = build_env(
-            "aarch64-linux-android",
-            &ndk_home,
-            &Version::new(28, 0, 0),
-            "--target=aarch64-linux-android28",
-            28,
-            "arm64-v8a",
-            false,
-            false,
-        );
+        let env = BuildConfig::new(ndk, Target::Arm64V8a, ApiLevel::new(28))
+            .with_linker("/cargo-ndk")
+            .environment()
+            .expect("environment should be generated");
 
-        assert_eq!(PathBuf::from(env["LIBCLANG_PATH"].clone()), libclang_path);
+        assert_eq!(
+            PathBuf::from(env.get("LIBCLANG_PATH").unwrap()),
+            libclang_path
+        );
 
         fs::remove_dir_all(ndk_home).ok();
     }

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -3,9 +3,8 @@ use std::{collections::BTreeMap, ffi::OsString};
 use clap::Parser;
 
 use crate::{
-    cargo::build_env,
-    clang_target,
-    cli::{derive_ndk_path, derive_ndk_version, init},
+    ApiLevel, BuildConfig,
+    cli::{cargo_ndk_executable_path, cargo_ndk_runner_path, discover_ndk, init},
     meta::Target,
 };
 
@@ -72,34 +71,26 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
     let (mut shell, args) = init::<EnvArgs>(args)?;
     let args = EnvArgs::try_parse_from(args)?;
 
-    let (ndk_home, _ndk_detection_method) = match derive_ndk_path(&mut shell) {
-        Some((path, method)) => (path, method),
-        None => {
+    let ndk = match discover_ndk(&mut shell) {
+        Ok(Some(ndk)) => ndk,
+        Ok(None) => {
             shell.error("Could not find any NDK.")?;
             shell.note(
                 "Set the environment ANDROID_NDK_HOME to your NDK installation's root directory,\nor install the NDK using Android Studio."
             )?;
             std::process::exit(1);
         }
+        Err(error) => return Err(error),
     };
 
-    let ndk_version = derive_ndk_version(&ndk_home)?;
-    let clang_target = clang_target(args.target.triple(), args.platform);
+    let config = BuildConfig::new(ndk, args.target, ApiLevel::new(args.platform))
+        .with_linker(cargo_ndk_executable_path()?)
+        .with_runner(cargo_ndk_runner_path()?)
+        .with_link_builtins(args.link_builtins)
+        .with_link_cxx_shared(args.link_libcxx_shared);
 
     // Try command line, then config. Config falls back to defaults in any case.
-    let env = filter_env(
-        build_env(
-            args.target.triple(),
-            &ndk_home,
-            &ndk_version,
-            &clang_target,
-            args.platform,
-            &args.target.to_string(),
-            args.link_builtins,
-            args.link_libcxx_shared,
-        ),
-        args.include_internal,
-    );
+    let env = filter_env(config.environment()?.into_map(), args.include_internal);
 
     if args.json {
         println!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,7 +4,7 @@ pub mod test;
 
 use std::{
     ffi::OsString,
-    fs, io,
+    fs,
     panic::PanicHookInfo,
     path::{Path, PathBuf},
     process::Command,
@@ -12,15 +12,14 @@ use std::{
 };
 
 use anyhow::Context;
-use cargo_metadata::{Artifact, CrateType, MetadataCommand, semver::Version};
+use cargo_metadata::{Artifact, CrateType, MetadataCommand};
 use clap::Parser;
 use filetime::FileTime;
 
 use crate::{
-    ARCH,
+    Ndk,
     meta::{Target, default_targets},
     shell::{Shell, Verbosity},
-    sysroot_suffix, sysroot_target,
 };
 
 trait CommandExt {
@@ -68,26 +67,6 @@ struct BuildArgs {
     cargo_args: Vec<String>,
 }
 
-fn highest_version_ndk_in_path(ndk_dir: &Path) -> Option<PathBuf> {
-    if ndk_dir.exists() {
-        fs::read_dir(ndk_dir)
-            .ok()?
-            .filter_map(Result::ok)
-            .filter_map(|x| {
-                let path = x.path();
-                path.components()
-                    .next_back()
-                    .and_then(|comp| comp.as_os_str().to_str())
-                    .and_then(|name| Version::parse(name).ok())
-                    .map(|version| (version, path))
-            })
-            .max_by(|(a, _), (b, _)| a.cmp(b))
-            .map(|(_, path)| path)
-    } else {
-        None
-    }
-}
-
 /// Return the name and value of the first environment variable that is set
 ///
 /// Additionally checks that if any other variables are set then they should
@@ -114,63 +93,6 @@ fn find_first_consistent_var_set<'a>(
     }
 
     first_var_set
-}
-
-/// Return a path to a discovered NDK and string describing how it was found
-fn derive_ndk_path(shell: &mut Shell) -> Option<(PathBuf, String)> {
-    let ndk_vars = [
-        "ANDROID_NDK_HOME",
-        "ANDROID_NDK_ROOT",
-        "ANDROID_NDK_PATH",
-        "NDK_HOME",
-    ];
-    if let Some((var_name, path)) = find_first_consistent_var_set(&ndk_vars, shell) {
-        let path = PathBuf::from(path);
-        return highest_version_ndk_in_path(&path)
-            .or(Some(path))
-            .map(|path| (path, var_name.to_string()));
-    }
-
-    let sdk_vars = ["ANDROID_HOME", "ANDROID_SDK_ROOT", "ANDROID_SDK_HOME"];
-    if let Some((var_name, sdk_path)) = find_first_consistent_var_set(&sdk_vars, shell) {
-        let ndk_path = PathBuf::from(&sdk_path).join("ndk");
-        if let Some(v) = highest_version_ndk_in_path(&ndk_path) {
-            return Some((v, var_name.to_string()));
-        }
-    }
-
-    let ndk_dir = default_ndk_dir();
-    highest_version_ndk_in_path(&ndk_dir).map(|path| (path, "standard location".to_string()))
-}
-
-fn default_ndk_dir() -> PathBuf {
-    #[cfg(windows)]
-    let dir = pathos::user::local_dir()
-        .unwrap()
-        .to_path_buf()
-        .join("Android")
-        .join("sdk")
-        .join("ndk");
-
-    #[cfg(target_os = "linux")]
-    let dir = pathos::xdg::home_dir()
-        .unwrap()
-        .join("Android")
-        .join("Sdk")
-        .join("ndk");
-
-    #[cfg(target_os = "macos")]
-    let dir = pathos::user::home_dir()
-        .unwrap()
-        .join("Library")
-        .join("Android")
-        .join("sdk")
-        .join("ndk");
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    let dir = PathBuf::new();
-
-    dir
 }
 
 /// Return a path to adb executable, resolving from ANDROID_HOME or ANDROID_SDK_ROOT
@@ -205,27 +127,35 @@ fn derive_adb_path(shell: &mut Shell) -> anyhow::Result<PathBuf> {
     ))
 }
 
-fn derive_ndk_version(path: &Path) -> anyhow::Result<Version> {
-    let data = fs::read_to_string(path.join("source.properties"))?;
-    for line in data.split('\n') {
-        if line.starts_with("Pkg.Revision") {
-            let mut chunks = line.split(" = ");
-            let _ = chunks.next().ok_or_else(|| io::Error::other("No chunk"))?;
-            let version = chunks.next().ok_or_else(|| io::Error::other("No chunk"))?;
-            let version = match Version::parse(version) {
-                Ok(v) => v,
-                Err(_e) => {
-                    return Err(anyhow::anyhow!(format!(
-                        "Could not parse NDK version. Got: '{}'",
-                        version
-                    )));
-                }
-            };
-            return Ok(version);
+pub(crate) fn discover_ndk(shell: &mut Shell) -> anyhow::Result<Option<Ndk>> {
+    let mut warning_error = None;
+    let ndk = Ndk::discover_with_warning(|warning| {
+        if warning_error.is_none() {
+            warning_error = shell.warn(warning).err();
         }
+    })?;
+
+    if let Some(error) = warning_error {
+        return Err(error);
     }
 
-    Err(anyhow::anyhow!("Could not find Pkg.Revision in given path"))
+    Ok(ndk)
+}
+
+pub(crate) fn cargo_ndk_executable_path() -> anyhow::Result<PathBuf> {
+    sibling_executable("cargo-ndk")
+}
+
+pub(crate) fn cargo_ndk_runner_path() -> anyhow::Result<PathBuf> {
+    sibling_executable("cargo-ndk-runner")
+}
+
+fn sibling_executable(name: &str) -> anyhow::Result<PathBuf> {
+    let current_executable = dunce::canonicalize(std::env::current_exe()?)?;
+    let parent = current_executable
+        .parent()
+        .context("current executable has no parent directory")?;
+    Ok(parent.join(name))
 }
 
 fn is_supported_rustc_version() -> bool {
@@ -468,25 +398,18 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
 
     // We used to check for NDK_HOME, so we'll keep doing that. But we'll also try ANDROID_NDK_HOME
     // and $ANDROID_SDK_HOME/ndk as this is how Android Studio configures the world
-    let (ndk_home, ndk_detection_method) = match derive_ndk_path(&mut shell) {
-        Some((path, method)) => (path, method),
-        None => {
+    let ndk = match discover_ndk(&mut shell) {
+        Ok(Some(ndk)) => ndk,
+        Ok(None) => {
             shell.error("Could not find any NDK.")?;
             shell.note(
                 "Set the environment ANDROID_NDK_HOME to your NDK installation's root directory,\nor install the NDK using Android Studio."
             )?;
             std::process::exit(1);
         }
-    };
-
-    let ndk_version = match derive_ndk_version(&ndk_home) {
-        Ok(v) => v,
-        Err(e) => {
-            shell.error(format!(
-                "Error detecting NDK version for path {}",
-                ndk_home.display()
-            ))?;
-            shell.error(e)?;
+        Err(error) => {
+            shell.error("Failed to detect the Android NDK.")?;
+            shell.error(error)?;
             std::process::exit(1);
         }
     };
@@ -496,9 +419,9 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
             "Detected",
             format!(
                 "NDK v{} ({}) [{}]",
-                ndk_version,
-                ndk_home.display(),
-                ndk_detection_method
+                ndk.version(),
+                ndk.path().display(),
+                ndk.source()
             ),
             termcolor::Color::Cyan,
         )
@@ -533,10 +456,9 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
         })
         .unwrap_or_else(|| working_dir.join("Cargo.toml"));
 
-    let cmake_toolchain_path = ndk_home
-        .join("build")
-        .join("cmake")
-        .join("android.toolchain.cmake");
+    let cargo_ndk_path = cargo_ndk_executable_path()?;
+    let cargo_ndk_runner_path = cargo_ndk_runner_path()?;
+    let cmake_toolchain_path = ndk.cmake_toolchain_path();
 
     shell.very_verbose(|shell| {
         shell.status_with_color(
@@ -664,11 +586,11 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
             let (status, artifacts) = crate::cargo::run(
                 &mut shell,
                 &working_dir,
-                &ndk_home,
-                &ndk_version,
-                triple,
+                &ndk,
+                target,
                 platform,
-                &android_abi,
+                &cargo_ndk_path,
+                &cargo_ndk_runner_path,
                 args.link_builtins,
                 args.link_libcxx_shared,
                 &args.cargo_args,
@@ -729,8 +651,8 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
             }
 
             if args.link_libcxx_shared {
-                let cargo_ndk_sysroot_path = ndk_home.join(sysroot_suffix(ARCH));
-                let cargo_ndk_sysroot_target = sysroot_target(target.triple());
+                let cargo_ndk_sysroot_path = ndk.sysroot();
+                let cargo_ndk_sysroot_target = target.sysroot_target();
                 let cargo_ndk_sysroot_libs_path = cargo_ndk_sysroot_path
                     .join("usr")
                     .join("lib")

--- a/src/cli/test.rs
+++ b/src/cli/test.rs
@@ -3,8 +3,11 @@ use std::{env, path::PathBuf, process::Command};
 use clap::Parser;
 
 use crate::{
-    clang_target,
-    cli::{HasCargoArgs, derive_adb_path, derive_ndk_path, derive_ndk_version, init},
+    ApiLevel, BuildConfig,
+    cli::{
+        HasCargoArgs, cargo_ndk_executable_path, cargo_ndk_runner_path, derive_adb_path,
+        discover_ndk, init,
+    },
     meta::Target,
 };
 
@@ -91,25 +94,18 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
     })?;
 
     // Get NDK path for building
-    let (ndk_home, ndk_detection_method) = match derive_ndk_path(&mut shell) {
-        Some((path, method)) => (path, method),
-        None => {
+    let ndk = match discover_ndk(&mut shell) {
+        Ok(Some(ndk)) => ndk,
+        Ok(None) => {
             shell.error("Could not find any NDK.")?;
             shell.note(
                 "Set the environment ANDROID_NDK_HOME to your NDK installation's root directory,\nor install the NDK using Android Studio."
             )?;
             std::process::exit(1);
         }
-    };
-
-    let ndk_version = match derive_ndk_version(&ndk_home) {
-        Ok(v) => v,
-        Err(e) => {
-            shell.error(format!(
-                "Error detecting NDK version for path {}",
-                ndk_home.display()
-            ))?;
-            shell.error(e)?;
+        Err(error) => {
+            shell.error("Failed to detect the Android NDK.")?;
+            shell.error(error)?;
             std::process::exit(1);
         }
     };
@@ -119,9 +115,9 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
             "Detected",
             format!(
                 "NDK v{} ({}) [{}]",
-                ndk_version,
-                ndk_home.display(),
-                ndk_detection_method
+                ndk.version(),
+                ndk.path().display(),
+                ndk.source()
             ),
             termcolor::Color::Cyan,
         )
@@ -133,18 +129,13 @@ pub fn run(args: Vec<String>) -> anyhow::Result<()> {
 
     // Set up environment for cargo test build
     let triple = target.triple();
-    let clang_target = clang_target(triple, platform);
-
-    let env_vars = crate::cargo::build_env(
-        triple,
-        &ndk_home,
-        &ndk_version,
-        &clang_target,
-        platform,
-        &target.to_string(),
-        args.link_builtins,
-        args.link_cxx_shared,
-    );
+    let env_vars = BuildConfig::new(ndk, target, ApiLevel::new(platform))
+        .with_linker(cargo_ndk_executable_path()?)
+        .with_runner(cargo_ndk_runner_path()?)
+        .with_link_builtins(args.link_builtins)
+        .with_link_cxx_shared(args.link_cxx_shared)
+        .environment()?
+        .into_map();
 
     shell.verbose(|shell| {
         shell.status_with_color(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,14 @@
-use std::path::PathBuf;
-
 pub mod cargo;
 pub mod cli;
+mod linker;
 pub mod meta;
+mod ndk;
 pub mod shell;
+
+pub use cargo::{BuildConfig, BuildEnvironment};
+pub use linker::run_linker_wrapper;
+pub use meta::{AndroidTarget, ApiLevel, Target};
+pub use ndk::{Ndk, NdkSource, NdkVersion};
 
 #[cfg(target_os = "macos")]
 pub(crate) const ARCH: &str = "darwin-x86_64";
@@ -28,31 +33,3 @@ Set CARGO_NDK_ON_ANDROID to override this check (for example, building for Termu
     target_os = "windows"
 )))]
 compile_error!("Unsupported target OS");
-
-pub(crate) fn clang_target(rust_target: &str, api_level: u8) -> String {
-    let target = match rust_target {
-        "arm-linux-androideabi" => "armv7a-linux-androideabi",
-        "armv7-linux-androideabi" => "armv7a-linux-androideabi",
-        _ => rust_target,
-    };
-    format!("--target={target}{api_level}")
-}
-
-pub(crate) fn sysroot_target(rust_target: &str) -> &str {
-    (match rust_target {
-        "armv7-linux-androideabi" => "arm-linux-androideabi",
-        _ => rust_target,
-    }) as _
-}
-
-pub(crate) fn ndk_tool(arch: &str, tool: &str) -> PathBuf {
-    ["toolchains", "llvm", "prebuilt", arch, "bin", tool]
-        .iter()
-        .collect()
-}
-
-pub(crate) fn sysroot_suffix(arch: &str) -> PathBuf {
-    ["toolchains", "llvm", "prebuilt", arch, "sysroot"]
-        .iter()
-        .collect()
-}

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -1,0 +1,94 @@
+use std::{
+    env,
+    ffi::{OsStr, OsString},
+    process::{Command, ExitStatus},
+};
+
+use anyhow::{Context, Result};
+
+const LINK_CLANG: &str = "_CARGO_NDK_LINK_CLANG";
+const LINK_TARGET: &str = "_CARGO_NDK_LINK_TARGET";
+const LINK_LDFLAGS: &str = "_CARGO_NDK_LDFLAGS";
+
+/// Runs the linker wrapper using the internal environment variables prepared
+/// by [`crate::BuildConfig`].
+///
+/// The function does not terminate the process. An embedding executable can
+/// return or translate the resulting status code according to its own CLI
+/// conventions.
+pub fn run_linker_wrapper() -> Result<ExitStatus> {
+    let clang = required_env(LINK_CLANG)?;
+    let target = required_env(LINK_TARGET)?;
+    let ldflags = env::var_os(LINK_LDFLAGS);
+
+    linker_command(env::args_os().skip(1), &clang, &target, ldflags.as_deref())
+        .status()
+        .with_context(|| {
+            format!(
+                "cargo-ndk linker: failed to execute {}",
+                PathDisplay(&clang)
+            )
+        })
+}
+
+fn required_env(name: &str) -> Result<OsString> {
+    env::var_os(name)
+        .ok_or_else(|| anyhow::anyhow!("cargo-ndk rustc linker: didn't find {name} env var"))
+}
+
+fn linker_command<I>(args: I, clang: &OsStr, target: &OsStr, ldflags: Option<&OsStr>) -> Command
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut command = Command::new(clang);
+    command.arg(target);
+
+    if let Some(ldflags) = ldflags {
+        for flag in ldflags.to_string_lossy().split('\x1f') {
+            command.arg(flag);
+        }
+    }
+
+    command.args(args);
+    command
+}
+
+struct PathDisplay<'a>(&'a OsStr);
+
+impl std::fmt::Display for PathDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0.to_string_lossy())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::{OsStr, OsString};
+
+    use super::linker_command;
+
+    #[test]
+    fn linker_command_places_target_and_flags_before_cargo_arguments() {
+        let command = linker_command(
+            vec![OsString::from("-shared"), OsString::from("output.so")],
+            OsStr::new("clang"),
+            OsStr::new("--target=aarch64-linux-android28"),
+            Some(OsStr::new(
+                "-Lbuiltins\x1f-lclang_rt.builtins-aarch64-android",
+            )),
+        );
+
+        assert_eq!(command.get_program(), OsStr::new("clang"));
+        let args = command.get_args().collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            vec![
+                OsStr::new("--target=aarch64-linux-android28"),
+                OsStr::new("-Lbuiltins"),
+                OsStr::new("-lclang_rt.builtins-aarch64-android"),
+                OsStr::new("-shared"),
+                OsStr::new("output.so"),
+            ]
+        );
+    }
+}

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -9,7 +9,50 @@ pub(crate) fn default_targets() -> &'static [Target] {
     &[Target::ArmeabiV7a, Target::Arm64V8a]
 }
 
-#[derive(Debug, Deserialize, Copy, Clone)]
+/// An Android API level used when selecting the NDK platform libraries.
+#[derive(Debug, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ApiLevel(u8);
+
+impl ApiLevel {
+    /// Creates an API level from its numeric representation.
+    pub const fn new(value: u8) -> Self {
+        Self(value)
+    }
+
+    /// Returns the numeric API level.
+    pub const fn get(self) -> u8 {
+        self.0
+    }
+}
+
+impl Default for ApiLevel {
+    fn default() -> Self {
+        Self::new(21)
+    }
+}
+
+impl From<u8> for ApiLevel {
+    fn from(value: u8) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Display for ApiLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for ApiLevel {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self::new)
+    }
+}
+
+/// A Rust-supported Android target and its corresponding Android ABI.
+#[derive(Debug, Deserialize, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Target {
     #[serde(rename = "armeabi-v7a")]
     ArmeabiV7a,
@@ -58,16 +101,12 @@ impl FromStr for Target {
 
 impl Display for Target {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            Target::ArmeabiV7a => "armeabi-v7a",
-            Target::Arm64V8a => "arm64-v8a",
-            Target::X86 => "x86",
-            Target::X86_64 => "x86_64",
-        })
+        f.write_str(self.abi())
     }
 }
 
 impl Target {
+    /// Returns the Rust target triple used by Cargo.
     pub fn triple(&self) -> &'static str {
         match self {
             Target::ArmeabiV7a => "armv7-linux-androideabi",
@@ -75,5 +114,107 @@ impl Target {
             Target::X86 => "i686-linux-android",
             Target::X86_64 => "x86_64-linux-android",
         }
+    }
+
+    /// Returns the Android ABI directory name for this target.
+    pub fn abi(&self) -> &'static str {
+        match self {
+            Target::ArmeabiV7a => "armeabi-v7a",
+            Target::Arm64V8a => "arm64-v8a",
+            Target::X86 => "x86",
+            Target::X86_64 => "x86_64",
+        }
+    }
+
+    /// Returns the Clang target triple used by the NDK linker wrapper.
+    pub fn clang_triple(&self) -> &'static str {
+        match self {
+            Target::ArmeabiV7a => "armv7a-linux-androideabi",
+            Target::Arm64V8a => "aarch64-linux-android",
+            Target::X86 => "i686-linux-android",
+            Target::X86_64 => "x86_64-linux-android",
+        }
+    }
+
+    /// Returns the `--target` argument passed to the NDK Clang executable.
+    pub fn clang_target(&self, api_level: ApiLevel) -> String {
+        format!("--target={}{}", self.clang_triple(), api_level)
+    }
+
+    /// Returns the target directory name used inside the NDK sysroot.
+    pub fn sysroot_target(&self) -> &'static str {
+        match self {
+            Target::ArmeabiV7a => "arm-linux-androideabi",
+            Target::Arm64V8a => "aarch64-linux-android",
+            Target::X86 => "i686-linux-android",
+            Target::X86_64 => "x86_64-linux-android",
+        }
+    }
+
+    /// Returns whether this target uses a 64-bit Android ABI.
+    pub fn is_64_bit(&self) -> bool {
+        matches!(self, Target::Arm64V8a | Target::X86_64)
+    }
+}
+
+/// A descriptive alias for [`Target`] when used outside the CLI layer.
+pub type AndroidTarget = Target;
+
+#[cfg(test)]
+mod tests {
+    use super::{ApiLevel, Target};
+
+    #[test]
+    fn target_mapping_covers_abi_clang_and_sysroot_names() {
+        let cases = [
+            (
+                Target::ArmeabiV7a,
+                "armeabi-v7a",
+                "armv7-linux-androideabi",
+                "armv7a-linux-androideabi",
+                "arm-linux-androideabi",
+            ),
+            (
+                Target::Arm64V8a,
+                "arm64-v8a",
+                "aarch64-linux-android",
+                "aarch64-linux-android",
+                "aarch64-linux-android",
+            ),
+            (
+                Target::X86,
+                "x86",
+                "i686-linux-android",
+                "i686-linux-android",
+                "i686-linux-android",
+            ),
+            (
+                Target::X86_64,
+                "x86_64",
+                "x86_64-linux-android",
+                "x86_64-linux-android",
+                "x86_64-linux-android",
+            ),
+        ];
+
+        for (target, abi, triple, clang_triple, sysroot_target) in cases {
+            assert_eq!(target.abi(), abi);
+            assert_eq!(target.triple(), triple);
+            assert_eq!(target.clang_triple(), clang_triple);
+            assert_eq!(target.sysroot_target(), sysroot_target);
+            assert_eq!(
+                target.clang_target(ApiLevel::new(28)),
+                format!("--target={clang_triple}28")
+            );
+        }
+    }
+
+    #[test]
+    fn api_level_round_trips_through_its_numeric_value() {
+        let api_level = ApiLevel::new(29);
+
+        assert_eq!(api_level.get(), 29);
+        assert_eq!(api_level.to_string(), "29");
+        assert_eq!("29".parse::<ApiLevel>().unwrap(), api_level);
     }
 }

--- a/src/ndk.rs
+++ b/src/ndk.rs
@@ -1,0 +1,368 @@
+use std::{
+    env,
+    ffi::OsString,
+    fmt, fs, io,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Result;
+use cargo_metadata::semver::Version;
+
+use crate::ARCH;
+
+const MIN_SUPPORTED_NDK_MAJOR: u64 = 23;
+
+/// A parsed Android NDK revision.
+///
+/// The representation is intentionally independent of the `cargo_metadata`
+/// crate so callers do not need to depend on cargo metadata types just to
+/// inspect the NDK version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NdkVersion(Version);
+
+impl NdkVersion {
+    /// Returns the major component of the NDK revision.
+    pub fn major(&self) -> u64 {
+        self.0.major
+    }
+
+    /// Returns the minor component of the NDK revision.
+    pub fn minor(&self) -> u64 {
+        self.0.minor
+    }
+
+    /// Returns the patch component of the NDK revision.
+    pub fn patch(&self) -> u64 {
+        self.0.patch
+    }
+
+    fn from_version(version: Version) -> Self {
+        Self(version)
+    }
+}
+
+impl fmt::Display for NdkVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl PartialOrd for NdkVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for NdkVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+/// Describes how an [`Ndk`] installation was discovered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NdkSource {
+    /// An NDK-specific environment variable, such as `ANDROID_NDK_HOME`.
+    Environment(&'static str),
+    /// An Android SDK environment variable, such as `ANDROID_HOME`.
+    AndroidSdk(&'static str),
+    /// The default Android SDK location for the host operating system.
+    StandardLocation,
+    /// A path supplied directly to [`Ndk::from_path`].
+    Explicit,
+}
+
+impl fmt::Display for NdkSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Environment(variable) | Self::AndroidSdk(variable) => f.write_str(variable),
+            Self::StandardLocation => f.write_str("standard location"),
+            Self::Explicit => f.write_str("explicit path"),
+        }
+    }
+}
+
+/// An Android NDK installation and its parsed revision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ndk {
+    path: PathBuf,
+    version: NdkVersion,
+    source: NdkSource,
+}
+
+impl Ndk {
+    /// Loads an NDK from a known installation directory.
+    pub fn from_path(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        let version = read_version(&path)?;
+
+        Ok(Self {
+            path,
+            version,
+            source: NdkSource::Explicit,
+        })
+    }
+
+    /// Discovers an NDK using the same environment variables and standard
+    /// locations as the `cargo ndk` command.
+    ///
+    /// `Ok(None)` means that no candidate installation could be found. A
+    /// candidate with an unreadable or invalid `source.properties` file is
+    /// returned as an error instead of silently trying a different one.
+    pub fn discover() -> Result<Option<Self>> {
+        Self::discover_with_warning(|_| {})
+    }
+
+    /// Discovers an NDK and reports conflicts between equivalent environment
+    /// variables to the supplied callback. This is useful for CLI frontends
+    /// that want to preserve their own warning/output policy.
+    pub fn discover_with_warning<F>(mut warning: F) -> Result<Option<Self>>
+    where
+        F: FnMut(String),
+    {
+        let Some((path, source)) = discover_path(&mut warning) else {
+            return Ok(None);
+        };
+
+        let mut ndk = Self::from_path(path)?;
+        ndk.source = source;
+        Ok(Some(ndk))
+    }
+
+    /// Returns the root directory of the NDK installation.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns the parsed NDK revision from `source.properties`.
+    pub fn version(&self) -> &NdkVersion {
+        &self.version
+    }
+
+    /// Checks whether this NDK can be used for an Android build.
+    ///
+    /// NDK releases before r23 are not supported by cargo-ndk's toolchain
+    /// configuration.
+    pub fn ensure_supported(&self) -> Result<()> {
+        if self.version.major() < MIN_SUPPORTED_NDK_MAJOR {
+            anyhow::bail!(
+                "NDK versions less than r23 are not supported. Install an up-to-date version of the NDK."
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Returns how this installation was obtained.
+    pub fn source(&self) -> NdkSource {
+        self.source
+    }
+
+    pub(crate) fn tool(&self, name: &str) -> PathBuf {
+        self.path
+            .join("toolchains")
+            .join("llvm")
+            .join("prebuilt")
+            .join(ARCH)
+            .join("bin")
+            .join(name)
+    }
+
+    pub(crate) fn sysroot(&self) -> PathBuf {
+        self.path
+            .join("toolchains")
+            .join("llvm")
+            .join("prebuilt")
+            .join(ARCH)
+            .join("sysroot")
+    }
+
+    pub(crate) fn cmake_toolchain_path(&self) -> PathBuf {
+        self.path
+            .join("build")
+            .join("cmake")
+            .join("android.toolchain.cmake")
+    }
+}
+
+fn discover_path<F>(warning: &mut F) -> Option<(PathBuf, NdkSource)>
+where
+    F: FnMut(String),
+{
+    let ndk_vars = [
+        "ANDROID_NDK_HOME",
+        "ANDROID_NDK_ROOT",
+        "ANDROID_NDK_PATH",
+        "NDK_HOME",
+    ];
+    if let Some((variable, path)) = find_first_consistent_var_set(&ndk_vars, warning) {
+        let path = PathBuf::from(path);
+        return highest_version_ndk_in_path(&path)
+            .or(Some(path))
+            .map(|path| (path, NdkSource::Environment(variable)));
+    }
+
+    let sdk_vars = ["ANDROID_HOME", "ANDROID_SDK_ROOT", "ANDROID_SDK_HOME"];
+    if let Some((variable, sdk_path)) = find_first_consistent_var_set(&sdk_vars, warning) {
+        let ndk_path = PathBuf::from(&sdk_path).join("ndk");
+        if let Some(path) = highest_version_ndk_in_path(&ndk_path) {
+            return Some((path, NdkSource::AndroidSdk(variable)));
+        }
+    }
+
+    default_ndk_dir()
+        .and_then(|path| highest_version_ndk_in_path(&path))
+        .map(|path| (path, NdkSource::StandardLocation))
+}
+
+fn find_first_consistent_var_set<F>(
+    vars: &[&'static str],
+    warning: &mut F,
+) -> Option<(&'static str, OsString)>
+where
+    F: FnMut(String),
+{
+    let mut first_var_set = None;
+    for variable in vars {
+        if let Some(path) = env::var_os(variable) {
+            if let Some((first_variable, first_path)) = first_var_set.as_ref() {
+                if *first_path != path {
+                    warning(format!(
+                        "Environment variable `{first_variable} = {first_path:#?}` doesn't match `{variable} = {path:#?}`"
+                    ));
+                }
+                continue;
+            }
+            first_var_set = Some((*variable, path));
+        }
+    }
+
+    first_var_set
+}
+
+fn highest_version_ndk_in_path(ndk_dir: &Path) -> Option<PathBuf> {
+    if ndk_dir.exists() {
+        fs::read_dir(ndk_dir)
+            .ok()?
+            .filter_map(Result::ok)
+            .filter_map(|entry| {
+                let path = entry.path();
+                path.components()
+                    .next_back()
+                    .and_then(|component| component.as_os_str().to_str())
+                    .and_then(|name| Version::parse(name).ok())
+                    .map(|version| (version, path))
+            })
+            .max_by(|(a, _), (b, _)| a.cmp(b))
+            .map(|(_, path)| path)
+    } else {
+        None
+    }
+}
+
+fn default_ndk_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    let dir = pathos::user::local_dir()
+        .ok()?
+        .to_path_buf()
+        .join("Android")
+        .join("sdk")
+        .join("ndk");
+
+    #[cfg(target_os = "linux")]
+    let dir = pathos::xdg::home_dir()
+        .ok()?
+        .join("Android")
+        .join("Sdk")
+        .join("ndk");
+
+    #[cfg(target_os = "macos")]
+    let dir = pathos::user::home_dir()
+        .ok()?
+        .join("Library")
+        .join("Android")
+        .join("sdk")
+        .join("ndk");
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    let dir = PathBuf::new();
+
+    Some(dir)
+}
+
+fn read_version(path: &Path) -> Result<NdkVersion> {
+    let data = fs::read_to_string(path.join("source.properties"))?;
+    for line in data.split('\n') {
+        if line.starts_with("Pkg.Revision") {
+            let mut chunks = line.split(" = ");
+            let _ = chunks.next().ok_or_else(|| io::Error::other("No chunk"))?;
+            let version = chunks.next().ok_or_else(|| io::Error::other("No chunk"))?;
+            let version = Version::parse(version).map_err(|_| {
+                anyhow::anyhow!(format!("Could not parse NDK version. Got: '{version}'"))
+            })?;
+            return Ok(NdkVersion::from_version(version));
+        }
+    }
+
+    Err(anyhow::anyhow!("Could not find Pkg.Revision in given path"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::{Ndk, NdkSource, highest_version_ndk_in_path};
+
+    fn temp_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before Unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("cargo-ndk-{name}-{nanos}"))
+    }
+
+    fn write_ndk(path: &PathBuf, version: &str) {
+        fs::create_dir_all(path).expect("failed to create fake NDK");
+        fs::write(
+            path.join("source.properties"),
+            format!("Pkg.Desc = Android NDK\nPkg.Revision = {version}\n"),
+        )
+        .expect("failed to write fake NDK metadata");
+    }
+
+    #[test]
+    fn loads_ndk_version_from_explicit_path() {
+        let path = temp_path("explicit-ndk");
+        write_ndk(&path, "28.0.12433566");
+
+        let ndk = Ndk::from_path(&path).expect("fake NDK should load");
+
+        assert_eq!(ndk.path(), path);
+        assert_eq!(ndk.version().to_string(), "28.0.12433566");
+        assert_eq!(ndk.version().major(), 28);
+        assert_eq!(ndk.version().minor(), 0);
+        assert_eq!(ndk.version().patch(), 12433566);
+        assert_eq!(ndk.source(), NdkSource::Explicit);
+
+        fs::remove_dir_all(path).ok();
+    }
+
+    #[test]
+    fn discovery_selects_the_highest_semver_named_ndk() {
+        let root = temp_path("versioned-ndk");
+        write_ndk(&root.join("25.2.9519653"), "25.2.9519653");
+        write_ndk(&root.join("28.0.12433566"), "28.0.12433566");
+        write_ndk(&root.join("not-an-ndk"), "1.0.0");
+
+        assert_eq!(
+            highest_version_ndk_in_path(&root),
+            Some(root.join("28.0.12433566"))
+        );
+
+        fs::remove_dir_all(root).ok();
+    }
+}

--- a/tests/cli_env.rs
+++ b/tests/cli_env.rs
@@ -1,0 +1,44 @@
+use std::{
+    fs,
+    path::PathBuf,
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn temp_path(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("cargo-ndk-cli-env-{name}-{nanos}"))
+}
+
+#[test]
+fn ndk_env_includes_the_cmake_toolchain_path() {
+    let ndk_path = temp_path("cmake");
+    fs::create_dir_all(&ndk_path).expect("failed to create fake NDK");
+    fs::write(
+        ndk_path.join("source.properties"),
+        "Pkg.Revision = 28.0.12433566\n",
+    )
+    .expect("failed to write fake NDK metadata");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-ndk-env"))
+        .args(["ndk-env", "--target", "arm64-v8a", "--json"])
+        .env("CARGO", "cargo")
+        .env("ANDROID_NDK_HOME", &ndk_path)
+        .output()
+        .expect("cargo-ndk-env should run");
+
+    assert!(
+        output.status.success(),
+        "cargo-ndk-env exited with {:?}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("JSON output should be UTF-8");
+    assert!(stdout.contains("CARGO_NDK_CMAKE_TOOLCHAIN_PATH"));
+    assert!(stdout.contains("android.toolchain.cmake"));
+
+    fs::remove_dir_all(ndk_path).ok();
+}

--- a/tests/fixtures/embedding/Cargo.toml
+++ b/tests/fixtures/embedding/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cargo-ndk-embedding-test"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+cargo-ndk = { path = "../../.." }

--- a/tests/fixtures/embedding/src/main.rs
+++ b/tests/fixtures/embedding/src/main.rs
@@ -1,0 +1,10 @@
+use std::process::exit;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if std::env::var_os("_CARGO_NDK_LINK_TARGET").is_some() {
+        let status = cargo_ndk::run_linker_wrapper()?;
+        exit(status.code().unwrap_or(1));
+    }
+
+    Ok(())
+}

--- a/tests/library_api.rs
+++ b/tests/library_api.rs
@@ -1,0 +1,176 @@
+use std::{
+    ffi::{OsStr, OsString},
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use cargo_ndk::{AndroidTarget, ApiLevel, BuildConfig, BuildEnvironment, Ndk};
+
+#[cfg(target_os = "macos")]
+const HOST_ARCH: &str = "darwin-x86_64";
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const HOST_ARCH: &str = "linux-x86_64";
+#[cfg(target_os = "windows")]
+const HOST_ARCH: &str = "windows-x86_64";
+
+fn temp_path(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("cargo-ndk-library-{name}-{nanos}"))
+}
+
+fn fake_ndk(path: &Path, version: &str) -> Ndk {
+    fs::create_dir_all(path).expect("failed to create fake NDK");
+    fs::write(
+        path.join("source.properties"),
+        format!("Pkg.Revision = {version}\n"),
+    )
+    .expect("failed to write fake NDK metadata");
+    Ndk::from_path(path).expect("fake NDK should load")
+}
+
+fn command_env(command: &Command, key: &str) -> Option<OsString> {
+    command
+        .get_envs()
+        .find(|(name, _)| *name == OsStr::new(key))
+        .and_then(|(_, value)| value.map(OsString::from))
+}
+
+fn assert_tool_env(environment: &BuildEnvironment, base: &str, tool: &Path) {
+    let target_prefix = format!("{base}_");
+    let target_env = format!("TARGET_{base}");
+    assert!(environment.iter().any(|(key, value)| {
+        (key == base || key == target_env || key.starts_with(&target_prefix))
+            && value == tool.as_os_str()
+    }));
+}
+
+#[test]
+fn library_configures_a_cargo_command_for_an_embedding_executable() {
+    let ndk_path = temp_path("command");
+    let ndk = fake_ndk(&ndk_path, "28.0.12433566");
+    let expected_linker = std::env::current_exe().expect("test executable should resolve");
+    let expected_cmake = ndk_path
+        .join("build")
+        .join("cmake")
+        .join("android.toolchain.cmake");
+    let expected_bin = ndk_path
+        .join("toolchains")
+        .join("llvm")
+        .join("prebuilt")
+        .join(HOST_ARCH)
+        .join("bin");
+    let config = BuildConfig::new(ndk, AndroidTarget::Arm64V8a, ApiLevel::new(28))
+        .with_link_cxx_shared(true);
+
+    let environment = config
+        .environment()
+        .expect("library environment should be generated");
+
+    assert_eq!(
+        environment.get("CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER"),
+        Some(expected_linker.as_os_str())
+    );
+    assert!(
+        environment
+            .get("CARGO_TARGET_AARCH64_LINUX_ANDROID_RUNNER")
+            .is_none()
+    );
+    assert_eq!(
+        environment.get("CARGO_NDK_SYSROOT_TARGET"),
+        Some(OsStr::new("aarch64-linux-android"))
+    );
+    assert_tool_env(&environment, "CC", &expected_bin.join("clang"));
+    assert_tool_env(&environment, "CXX", &expected_bin.join("clang++"));
+    assert_tool_env(&environment, "AR", &expected_bin.join("llvm-ar"));
+    assert_tool_env(&environment, "RANLIB", &expected_bin.join("llvm-ranlib"));
+    assert_eq!(
+        environment.get("CARGO_TARGET_AARCH64_LINUX_ANDROID_AR"),
+        Some(expected_bin.join("llvm-ar").as_os_str())
+    );
+    assert_eq!(
+        environment.get("CARGO_NDK_ANDROID_PLATFORM"),
+        Some(OsStr::new("28"))
+    );
+    assert_eq!(
+        environment.get("ANDROID_ABI"),
+        Some(OsStr::new("arm64-v8a"))
+    );
+    assert_eq!(
+        environment.get("_CARGO_NDK_LINK_TARGET"),
+        Some(OsStr::new("--target=aarch64-linux-android28"))
+    );
+    assert_eq!(
+        environment.get("CARGO_NDK_CMAKE_TOOLCHAIN_PATH"),
+        Some(expected_cmake.as_os_str())
+    );
+    assert!(
+        environment
+            .get("_CARGO_NDK_LDFLAGS")
+            .expect("libc++ flag should be exported")
+            .to_string_lossy()
+            .contains("-lc++_shared")
+    );
+
+    let mut command = Command::new("cargo");
+    config
+        .configure_command(&mut command)
+        .expect("configuration should apply to Cargo");
+    assert_eq!(
+        command_env(&command, "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER"),
+        Some(expected_linker.into_os_string())
+    );
+
+    fs::remove_dir_all(ndk_path).ok();
+}
+
+#[test]
+fn library_preserves_ndk_builtins_and_page_size_compatibility_flags() {
+    let ndk_path = temp_path("flags");
+    let ndk = fake_ndk(&ndk_path, "27.3.13750724");
+    let builtins_path = ndk_path
+        .join("toolchains")
+        .join("llvm")
+        .join("prebuilt")
+        .join(HOST_ARCH)
+        .join("lib")
+        .join("clang")
+        .join("18")
+        .join("lib")
+        .join("linux");
+    fs::create_dir_all(&builtins_path).expect("failed to create fake builtins directory");
+
+    let environment = BuildConfig::new(ndk, AndroidTarget::Arm64V8a, ApiLevel::new(28))
+        .with_link_builtins(true)
+        .with_linker("xtask")
+        .environment()
+        .expect("library environment should be generated");
+    let flags = environment
+        .get("_CARGO_NDK_LDFLAGS")
+        .expect("builtins flags should be exported")
+        .to_string_lossy();
+
+    assert!(flags.contains(&format!("-L{}", builtins_path.display())));
+    assert!(flags.contains("-lclang_rt.builtins-aarch64-android"));
+    assert!(flags.contains("-Wl,-z,max-page-size=16384"));
+    assert!(!flags.contains("common-page-size"));
+
+    fs::remove_dir_all(ndk_path).ok();
+}
+
+#[test]
+fn library_rejects_unsupported_ndk_versions_before_generating_environment() {
+    let ndk_path = temp_path("unsupported-version");
+    let ndk = fake_ndk(&ndk_path, "22.1.7171670");
+
+    let error = BuildConfig::new(ndk, AndroidTarget::Arm64V8a, ApiLevel::new(28))
+        .environment()
+        .expect_err("NDK versions before r23 should be rejected");
+
+    assert!(error.to_string().contains("less than r23"));
+    fs::remove_dir_all(ndk_path).ok();
+}

--- a/tests/linker_wrapper.rs
+++ b/tests/linker_wrapper.rs
@@ -1,0 +1,89 @@
+use std::{
+    fs,
+    path::PathBuf,
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn temp_path(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("cargo-ndk-wrapper-{name}-{nanos}"))
+}
+
+#[test]
+fn embedding_executable_dispatches_to_wrapper_without_cargo_ndk_binary() {
+    let directory = temp_path("dispatch");
+    fs::create_dir_all(&directory).expect("failed to create wrapper test directory");
+
+    #[cfg(windows)]
+    let (clang, linker_args) = {
+        let script = directory.join("fake-clang.cmd");
+        fs::write(&script, "@echo off\r\nexit /b 0\r\n")
+            .expect("failed to write fake clang script");
+        ("cmd.exe".to_string(), vec![script.into_os_string()])
+    };
+
+    #[cfg(not(windows))]
+    let (clang, linker_args) = {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script = directory.join("fake-clang");
+        fs::write(&script, "#!/bin/sh\nexit 0\n").expect("failed to write fake clang script");
+        let mut permissions = fs::metadata(&script)
+            .expect("fake clang metadata should be available")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).expect("failed to make fake clang executable");
+        (
+            script.to_string_lossy().into_owned(),
+            vec!["output.o".into()],
+        )
+    };
+
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("embedding")
+        .join("Cargo.toml");
+    let fixture_directory = manifest
+        .parent()
+        .expect("embedding fixture should have a parent directory");
+    let fixture_lockfile = fixture_directory.join("Cargo.lock");
+    let fixture_lockfile_existed = fixture_lockfile.exists();
+    let target_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("embedding-fixture");
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let output = Command::new(cargo)
+        .args(["--offline", "run", "--quiet", "--manifest-path"])
+        .arg(&manifest)
+        .args(["--target-dir"])
+        .arg(&target_dir)
+        .arg("--")
+        .args(linker_args)
+        .env_remove("CARGO")
+        .env(
+            "_CARGO_NDK_LINK_TARGET",
+            if cfg!(windows) { "/C" } else { "--target=test" },
+        )
+        .env("_CARGO_NDK_LINK_CLANG", clang)
+        .output()
+        .expect("cargo-ndk wrapper process should start");
+
+    if !fixture_lockfile_existed {
+        fs::remove_file(&fixture_lockfile).ok();
+    }
+    fs::remove_dir_all(&target_dir).ok();
+
+    assert!(
+        output.status.success(),
+        "embedded linker wrapper failed with {:?}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    fs::remove_dir_all(directory).ok();
+}


### PR DESCRIPTION
## Summary

This PR makes cargo-ndk usable as a regular Rust library for build tools such as xtask. Consumers can configure and launch their own Cargo commands while reusing cargo-ndk's Android NDK toolchain compatibility logic.

## Motivation

The previous implementation kept environment setup behind the CLI and assumed that a cargo-ndk executable would be available to act as the Rust linker wrapper. That makes library embedding awkward: an xtask would need an additional installed or sibling cargo-ndk executable.

## What changed

- Add a small structured API: Ndk, NdkVersion, AndroidTarget, ApiLevel, BuildConfig, and BuildEnvironment.
- Reuse NDK discovery, version validation, target/ABI/Clang/sysroot mapping, tool paths, Cargo/cc/bindgen environment variables, builtins and libc++_shared linking, and 16 KiB page-size compatibility flags.
- Move the linker-wrapper implementation into the library as run_linker_wrapper(), returning a Result<ExitStatus> instead of terminating the process.
- Keep the existing CLI commands and argument handling. The CLI remains responsible for presentation and process exit behavior, and continues to use its legacy sibling executable paths where required.
- Keep the existing single-package architecture; this does not add a cargo-ndk-core crate, new crate types, or new dependencies.

## Embedding model

An embedding executable can dispatch linker invocations to cargo-ndk before its normal command handling:

~~~rust
if std::env::var_os("_CARGO_NDK_LINK_TARGET").is_some() {
    let status = cargo_ndk::run_linker_wrapper()?;
    std::process::exit(status.code().unwrap_or(1));
}
~~~

It can then configure and launch Cargo itself:

~~~rust
let ndk = Ndk::discover()?
    .ok_or_else(|| std::io::Error::other("Android NDK was not found"))?;
let target = AndroidTarget::Arm64V8a;
let config = BuildConfig::new(ndk, target, ApiLevel::new(28));

let mut cargo = Command::new("cargo");
cargo.args(["build", "--target", target.triple()]);
config.configure_command(&mut cargo)?;
cargo.status()?;
~~~

The default linker is the current embedding executable, so this path does not look up or require a sibling cargo-ndk binary.

## Compatibility and tests

- NDK releases older than r23 are rejected at the library configuration boundary through Result.
- An independent tests/fixtures/embedding crate consumes cargo-ndk through a path dependency and runs as its own executable.
- Integration coverage verifies linker-wrapper dispatch without a cargo-ndk sibling, target/toolchain environment generation, NDK builtins and page-size flags, and cargo ndk-env CMake environment output.
- The existing CI workflow is unchanged; no additional GitHub Actions test job is added.

## Validation

- cargo fmt --all -- --check
- cargo build --locked --all-targets
- cargo test --locked --all-targets
- cargo clippy --locked --all-targets -- -D warnings
- cargo doc --locked --no-deps